### PR TITLE
[codex] simplify installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,39 @@ Together, these enable full-dimensional (Skill, Context, BrainModel) self-evolut
 
 ## Quick Start
 
-**Requirements:** Python 3.11+, an LLM API key (DeepSeek / OpenAI / Anthropic / Ollama / Gemini).
+**Requirements:** Python 3.11+. The base install now bundles Gemini, Feishu, Discord, Telegram, and other runtime dependencies, so users do not need to learn extras first.
 
 ### Installation
 
+`curl:`
+
 ```bash
-# 1. Install
-$ pip install -e .
-
-# 2. Interactive setup — choose provider, enter API key, done
+$ curl -fsSL https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh | bash
 $ omniagent onboard
+$ omniagent chat                    # CLI
+$ omniagent serve                   # Web UI → http://127.0.0.1:18790
+```
 
-# 3. Start
+If `omniagent` is not found in a new shell, add `~/.local/bin` to your `PATH`.
+
+`uv:`
+
+```bash
+$ uv venv --python 3.11
+$ uv sync
+$ uv run omniagent onboard
+$ uv run omniagent chat
+$ uv run omniagent serve            # Web UI → http://127.0.0.1:18790
+```
+
+`pip:`
+
+```bash
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ python -m pip install -U pip
+$ python -m pip install -e .
+$ omniagent onboard
 $ omniagent chat                    # CLI
 $ omniagent serve                   # Web UI → http://127.0.0.1:18790
 ```
@@ -102,8 +123,8 @@ $ omniagent serve                   # Web UI → http://127.0.0.1:18790
 | Mode | Command | Description |
 |------|---------|-------------|
 | **Terminal** | `omniagent chat` | Interactive chat in your terminal |
-| **Web UI** | `omniagent serve` | Start Gateway, open http://127.0.0.1:18790 in your browser |
-| **Mobile** (Feishu / Discord / Telegram) | `omniagent serve` | Start Gateway, configure Channel in `config.yaml`, then open a session in your terminal |
+| **Web UI** | `omniagent serve` | Start Gateway, then open http://127.0.0.1:18790 in your browser |
+| **Mobile** (Feishu / Discord / Telegram) | `omniagent serve` | Start Gateway, configure the channel in `~/.omniagent/config.yaml` (or pass `--config`), then message the bot on that platform |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Together, these enable full-dimensional (Skill, Context, BrainModel) self-evolut
 `curl:`
 
 ```bash
-$ curl -fsSL https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh | bash
+$ curl -fsSL https://raw.githubusercontent.com/YeQing17-2026/OmniAgent/main/install.sh | bash
 $ omniagent onboard
 $ omniagent chat                    # CLI
 $ omniagent serve                   # Web UI → http://127.0.0.1:18790

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,19 +84,40 @@
 
 ## 快速开始
 
-**环境要求：** Python 3.11+，LLM API Key（DeepSeek / OpenAI / Anthropic / Ollama / Gemini）。
+**环境要求：** Python 3.11+。基础安装已包含 Gemini、飞书、Discord、Telegram 等运行依赖，不再要求用户理解 extras。
 
 ### 安装
 
+`curl:`
+
 ```bash
-# 1. 初始化
-$ pip install -e .
-
-# 2.交互式配置向导 — 选择提供商、输入 API Key，一步到位
+$ curl -fsSL https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh | bash
 $ omniagent onboard
-
-# 3. 开启试用
 $ omniagent chat                    # CLI
+$ omniagent serve                   # Web UI → http://127.0.0.1:18790
+```
+
+如果新终端里找不到 `omniagent`，把 `~/.local/bin` 加到 `PATH`。
+
+`uv:`
+
+```bash
+$ uv venv --python 3.11
+$ uv sync
+$ uv run omniagent onboard
+$ uv run omniagent chat
+$ uv run omniagent serve            # Web UI → http://127.0.0.1:18790
+```
+
+`pip:`
+
+```bash
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ python -m pip install -U pip
+$ python -m pip install -e .
+$ omniagent onboard
+$ omniagent chat
 $ omniagent serve                   # Web UI → http://127.0.0.1:18790
 ```
 
@@ -105,8 +126,8 @@ $ omniagent serve                   # Web UI → http://127.0.0.1:18790
 | 方式 | 命令 | 说明 |
 |------|------|------|
 | **终端** | `omniagent chat` | 终端内交互式对话 |
-| **Web UI** | `omniagent serve` | 启动 Gateway，浏览器打开 http://127.0.0.1:18790 |
-| **移动端**（飞书 / Discord / Telegram） | `omniagent serve` | 启动 Gateway，并在 `config.yaml` 中配置 Channel，最后在终端打开会话 |
+| **Web UI** | `omniagent serve` | 启动 Gateway，然后在浏览器打开 http://127.0.0.1:18790 |
+| **移动端**（飞书 / Discord / Telegram） | `omniagent serve` | 启动 Gateway，并在 `~/.omniagent/config.yaml` 中配置渠道（或通过 `--config` 指定配置文件），然后直接在对应平台给机器人发消息 |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -91,7 +91,7 @@
 `curl:`
 
 ```bash
-$ curl -fsSL https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh | bash
+$ curl -fsSL https://raw.githubusercontent.com/YeQing17-2026/OmniAgent/main/install.sh | bash
 $ omniagent onboard
 $ omniagent chat                    # CLI
 $ omniagent serve                   # Web UI → http://127.0.0.1:18790

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
                     <span>Terminal</span>
                 </div>
                 <code><span class="comment"># 1. Install</span>
-<span class="prompt">$</span> <span class="cmd">pip install</span> <span class="arg">-e .</span>
+<span class="prompt">$</span> <span class="cmd">curl -fsSL</span> <span class="arg">https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh</span> <span class="comment">| bash</span>
 
 <span class="comment"># 2. Interactive setup</span>
 <span class="prompt">$</span> <span class="cmd">omniagent onboard</span>

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
                     <span>Terminal</span>
                 </div>
                 <code><span class="comment"># 1. Install</span>
-<span class="prompt">$</span> <span class="cmd">curl -fsSL</span> <span class="arg">https://raw.githubusercontent.com/YoungCan-Wang/OmniAgent/main/install.sh</span> <span class="comment">| bash</span>
+<span class="prompt">$</span> <span class="cmd">curl -fsSL</span> <span class="arg">https://raw.githubusercontent.com/YeQing17-2026/OmniAgent/main/install.sh</span> <span class="comment">| bash</span>
 
 <span class="comment"># 2. Interactive setup</span>
 <span class="prompt">$</span> <span class="cmd">omniagent onboard</span>

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-REPO="${OMNIAGENT_REPO:-YoungCan-Wang/OmniAgent}"
+REPO="${OMNIAGENT_REPO:-YeQing17-2026/OmniAgent}"
 REF="${OMNIAGENT_REF:-main}"
 INSTALL_BASE="${OMNIAGENT_INSTALL_DIR:-$HOME/.local/share/omniagent}"
 BIN_DIR="${OMNIAGENT_BIN_DIR:-$HOME/.local/bin}"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${OMNIAGENT_REPO:-YoungCan-Wang/OmniAgent}"
+REF="${OMNIAGENT_REF:-main}"
+INSTALL_BASE="${OMNIAGENT_INSTALL_DIR:-$HOME/.local/share/omniagent}"
+BIN_DIR="${OMNIAGENT_BIN_DIR:-$HOME/.local/bin}"
+TARBALL_URL="${OMNIAGENT_TARBALL_URL:-https://github.com/${REPO}/archive/refs/heads/${REF}.tar.gz}"
+
+log() {
+  printf '[OmniAgent installer] %s\n' "$1"
+}
+
+fail() {
+  printf '[OmniAgent installer] ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+find_python() {
+  if [ -n "${OMNIAGENT_PYTHON:-}" ] && command -v "${OMNIAGENT_PYTHON}" >/dev/null 2>&1; then
+    printf '%s' "${OMNIAGENT_PYTHON}"
+    return 0
+  fi
+
+  for candidate in python3.13 python3.12 python3.11 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+require_python_311() {
+  local python_bin="$1"
+
+  "$python_bin" -c '
+import sys
+sys.exit(0 if sys.version_info >= (3, 11) else 1)
+' || fail "Python 3.11+ is required. Set OMNIAGENT_PYTHON to a compatible interpreter and retry."
+}
+
+if ! command -v curl >/dev/null 2>&1; then
+  fail "curl is required."
+fi
+
+if ! command -v tar >/dev/null 2>&1; then
+  fail "tar is required."
+fi
+
+PYTHON_BIN="$(find_python || true)"
+[ -n "$PYTHON_BIN" ] || fail "Python 3.11+ was not found."
+require_python_311 "$PYTHON_BIN"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+ARCHIVE_PATH="$TMP_DIR/omniagent.tar.gz"
+EXTRACT_DIR="$TMP_DIR/extract"
+APP_DIR="$INSTALL_BASE/app"
+VENV_DIR="$INSTALL_BASE/venv"
+LAUNCHER_PATH="$BIN_DIR/omniagent"
+
+mkdir -p "$EXTRACT_DIR" "$INSTALL_BASE" "$BIN_DIR"
+
+log "Downloading source archive from $TARBALL_URL"
+curl -fsSL "$TARBALL_URL" -o "$ARCHIVE_PATH"
+
+log "Extracting archive"
+tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
+
+PYPROJECT_PATH="$(find "$EXTRACT_DIR" -mindepth 0 -maxdepth 2 -type f -name pyproject.toml | head -n 1)"
+[ -n "$PYPROJECT_PATH" ] || fail "Failed to locate pyproject.toml in the source archive."
+
+SRC_DIR="$(dirname "$PYPROJECT_PATH")"
+[ -n "$SRC_DIR" ] || fail "Failed to unpack source archive."
+
+rm -rf "$APP_DIR" "$VENV_DIR"
+mv "$SRC_DIR" "$APP_DIR"
+
+log "Creating virtual environment with $PYTHON_BIN"
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+
+log "Installing OmniAgent into $VENV_DIR"
+PIP_DISABLE_PIP_VERSION_CHECK=1 "$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel >/dev/null
+PIP_DISABLE_PIP_VERSION_CHECK=1 "$VENV_DIR/bin/python" -m pip install --no-build-isolation "$APP_DIR"
+
+cat > "$LAUNCHER_PATH" <<EOF
+#!/usr/bin/env bash
+exec "$VENV_DIR/bin/omniagent" "\$@"
+EOF
+chmod +x "$LAUNCHER_PATH"
+
+log "Installation complete."
+log "Binary: $LAUNCHER_PATH"
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*)
+    ;;
+  *)
+    log "Add $BIN_DIR to PATH if 'omniagent' is not found in a new shell."
+    ;;
+esac
+
+log "Next steps:"
+log "  omniagent onboard"
+log "  omniagent serve"

--- a/omniagent/agents/llm.py
+++ b/omniagent/agents/llm.py
@@ -878,8 +878,8 @@ class GoogleGeminiLLMProvider(LLMProvider):
                 logger.info("gemini_client_initialized", model=self.model)
             except ImportError:
                 raise RuntimeError(
-                    "google-generativeai package is required for Gemini provider. "
-                    "Install it with: pip install google-generativeai"
+                    "google-generativeai is missing from the current OmniAgent environment. "
+                    "Reinstall OmniAgent to restore bundled runtime dependencies."
                 )
 
     def _convert_messages(self, messages: List[LLMMessage]) -> tuple:

--- a/omniagent/channels/discord.py
+++ b/omniagent/channels/discord.py
@@ -50,7 +50,10 @@ class DiscordChannel(BaseChannel):
             logger.info("discord_client_initialized")
             return True
         except ImportError:
-            logger.warning("discord_not_installed", msg="discord.py is not installed. Install with: pip install discord.py")
+            logger.warning(
+                "discord_not_installed",
+                msg="discord.py is missing from the current OmniAgent environment. Reinstall OmniAgent to restore bundled runtime dependencies.",
+            )
             return False
 
     async def start(self) -> None:

--- a/omniagent/channels/feishu.py
+++ b/omniagent/channels/feishu.py
@@ -68,7 +68,10 @@ class FeishuChannel(BaseChannel):
     async def start(self) -> None:
         """Start the Feishu bot with WebSocket long connection."""
         if not FEISHU_AVAILABLE:
-            logger.error("feishu_sdk_not_installed", hint="pip install lark-oapi")
+            logger.error(
+                "feishu_sdk_not_installed",
+                hint="lark-oapi is missing from the current OmniAgent environment. Reinstall OmniAgent to restore bundled runtime dependencies.",
+            )
             return
 
         if not self.config.app_id or not self.config.app_secret:

--- a/omniagent/channels/telegram.py
+++ b/omniagent/channels/telegram.py
@@ -47,7 +47,10 @@ class TelegramChannel(BaseChannel):
             logger.info("telegram_client_initialized")
             return True
         except ImportError:
-            logger.warning("telegram_not_installed", msg="python-telegram-bot is not installed. Install with: pip install python-telegram-bot")
+            logger.warning(
+                "telegram_not_installed",
+                msg="python-telegram-bot is missing from the current OmniAgent environment. Reinstall OmniAgent to restore bundled runtime dependencies.",
+            )
             return False
 
     async def start(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,13 @@ dependencies = [
     "anthropic>=0.40.0",
     "beautifulsoup4>=4.12.0",
     "prompt-toolkit>=3.0.0",
+    "lark-oapi>=1.5.0",
+    "google-generativeai",
+    "discord.py",
+    "python-telegram-bot",
 ]
 
 [project.optional-dependencies]
-feishu = ["lark-oapi>=1.5.0"]
 dev = [
     "pytest>=7.4.3",
     "pytest-asyncio>=0.21.1",


### PR DESCRIPTION
## What changed

- bundled Gemini, Feishu, Discord, and Telegram runtime dependencies into the base install
- added a repository-level `install.sh` so the project can be installed via `curl | bash`
- simplified the installation sections in `README.md`, `README_CN.md`, and the landing page to show concise `curl`, `uv`, and `pip` entry points
- updated missing-dependency messaging so runtime errors point users to reinstall OmniAgent instead of manually installing individual extras

## Why

The installation flow required users to understand optional extras before they could use common providers and channels. This PR reduces that friction by making the default install self-contained and by adding a single-command installer for the fork/upstream workflow.

## User impact

- end users can install with one command via `curl -fsSL ... | bash`
- `pip install -e .` and `uv sync` now include the main runtime integrations by default
- installation instructions are shorter and more direct

## Validation

- `uv run omniagent --help`
- `uv run omniagent doctor`
- end-to-end run of `install.sh` against a local source tarball
- installed launcher validation with `omniagent --help` and `omniagent doctor` from the installer output path
