### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -15,7 +15,7 @@ from omniagent.infra import get_logger
 from omniagent.tools import (
     Tool, ToolRegistry, ReadTool, WriteTool, EditTool, BashTool,
     LoadJSONTool, SaveJSONTool, ProcessListTool, ProcessKillTool,
-    WebSearchTool, WebFetchTool,
+    WebSearchTool, WebFetchTool, ExaSearchTool,
 )
 from omniagent.tools.grep_tool import GrepTool
 from omniagent.tools.find_tool import FindTool
@@ -348,6 +348,7 @@ class ReflexionAgent(Agent):
         # Web tools
         self.registry.register(WebSearchTool())
         self.registry.register(WebFetchTool())
+        self.registry.register(ExaSearchTool())
 
         # Search/navigation tools
         self.registry.register(GrepTool(work_dir=self.work_dir))

--- a/omniagent/agents/skill_evolution.py
+++ b/omniagent/agents/skill_evolution.py
@@ -336,7 +336,7 @@ class PatternAnalyzer:
     _TOOL_NAME_MAP = {
         "read_file": "read", "write_file": "write", "edit_file": "edit",
         "bash": "shell", "grep": "search", "find": "locate",
-        "web_search": "websearch", "web_fetch": "fetch",
+        "web_search": "websearch", "web_fetch": "fetch", "exa_search": "exa",
         "diff": "diff", "load_json": "json", "save_json": "json-save",
         "ls": "list", "memory_search": "recall",
     }

--- a/omniagent/security/policy.py
+++ b/omniagent/security/policy.py
@@ -30,7 +30,7 @@ TOOL_GROUPS = {
     "fs": ["read_file", "write_file", "edit_file"],
     "search": ["grep", "find", "ls", "diff"],
     "runtime": ["bash"],
-    "web": ["web_search", "web_fetch"],
+    "web": ["web_search", "web_fetch", "exa_search"],
     "json": ["load_json", "save_json"],
     "process": ["process_list", "process_kill"],
     "memory": ["memory_search", "memory_get"],

--- a/omniagent/tools/__init__.py
+++ b/omniagent/tools/__init__.py
@@ -5,6 +5,7 @@ from .file_tools import ReadTool, WriteTool, EditTool
 from .bash_tool import BashTool
 from .json_tool import LoadJSONTool, SaveJSONTool
 from .web_tools import WebSearchTool, WebFetchTool
+from .exa_tool import ExaSearchTool
 from .process_tool import ProcessListTool, ProcessKillTool
 
 __all__ = [
@@ -19,6 +20,7 @@ __all__ = [
     "SaveJSONTool",
     "WebSearchTool",
     "WebFetchTool",
+    "ExaSearchTool",
     "ProcessListTool",
     "ProcessKillTool",
 ]

--- a/omniagent/tools/exa_tool.py
+++ b/omniagent/tools/exa_tool.py
@@ -1,0 +1,337 @@
+"""Exa AI-powered search tool."""
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from omniagent.infra import get_logger
+
+from .base import Tool, ToolResult
+
+logger = get_logger(__name__)
+
+
+_VALID_SEARCH_TYPES = {"auto", "neural", "fast", "deep", "deep-lite", "deep-reasoning", "instant"}
+_VALID_CATEGORIES = {
+    "company",
+    "research paper",
+    "news",
+    "personal site",
+    "financial report",
+    "people",
+}
+
+
+@dataclass
+class ExaSearchResult:
+    """Typed Exa search result."""
+
+    title: str
+    url: str
+    published_date: Optional[str] = None
+    author: Optional[str] = None
+    text: Optional[str] = None
+    summary: Optional[str] = None
+    highlights: List[str] = field(default_factory=list)
+    score: Optional[float] = None
+
+    @classmethod
+    def from_api(cls, item: Any) -> "ExaSearchResult":
+        """Build from an exa-py result object (attribute-style or dict)."""
+
+        def _attr(obj: Any, name: str, default: Any = None) -> Any:
+            if isinstance(obj, dict):
+                return obj.get(name, default)
+            return getattr(obj, name, default)
+
+        highlights = _attr(item, "highlights", []) or []
+        if not isinstance(highlights, list):
+            highlights = [str(highlights)]
+
+        return cls(
+            title=_attr(item, "title", "") or "",
+            url=_attr(item, "url", "") or "",
+            published_date=_attr(item, "published_date") or _attr(item, "publishedDate"),
+            author=_attr(item, "author"),
+            text=_attr(item, "text"),
+            summary=_attr(item, "summary"),
+            highlights=[str(h) for h in highlights],
+            score=_attr(item, "score"),
+        )
+
+    def snippet(self, max_chars: int = 500) -> str:
+        """Pick the best available content for a short snippet.
+
+        Cascades through highlights → summary → text so partial results from
+        the API still produce something readable.
+        """
+        if self.highlights:
+            joined = " ... ".join(self.highlights)
+            return joined[:max_chars]
+        if self.summary:
+            return self.summary[:max_chars]
+        if self.text:
+            return self.text[:max_chars]
+        return ""
+
+
+def _format_results(query: str, results: List[ExaSearchResult]) -> str:
+    """Format results as human-readable text matching the WebSearch style."""
+    if not results:
+        return f"No results found for: {query}"
+
+    lines: List[str] = [f"Search results for: {query}"]
+    for i, r in enumerate(results, 1):
+        block = [f"{i}. {r.title}", f"   URL: {r.url}"]
+        if r.published_date:
+            block.append(f"   Published: {r.published_date}")
+        if r.author:
+            block.append(f"   Author: {r.author}")
+        snippet = r.snippet()
+        if snippet:
+            block.append(f"   {snippet}")
+        lines.append("\n".join(block))
+
+    return lines[0] + "\n\n" + "\n\n".join(lines[1:])
+
+
+class ExaSearchTool(Tool):
+    """Web search powered by the Exa AI search API.
+
+    Exa returns embedding-based ("neural") and hybrid results plus optional
+    page contents (highlights, summary, full text). Requires an EXA_API_KEY
+    environment variable. See https://exa.ai for API access.
+    """
+
+    INTEGRATION_NAME = "omniagent"
+
+    def __init__(self, timeout: int = 30):
+        super().__init__(
+            name="exa_search",
+            description=(
+                "Search the web using Exa's AI-powered search API. "
+                "Returns titles, URLs, and content snippets (highlights or summary). "
+                "Supports neural/keyword/auto search, category filters (company, "
+                "research paper, news, personal site, financial report, people), "
+                "domain include/exclude, and date ranges. "
+                "Requires EXA_API_KEY environment variable."
+            ),
+        )
+        self.timeout = timeout
+        self.api_key = os.getenv("EXA_API_KEY", "")
+
+    def _get_parameters_schema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query string",
+                },
+                "num_results": {
+                    "type": "integer",
+                    "description": "Number of results to return (1-25, default: 5)",
+                    "default": 5,
+                },
+                "type": {
+                    "type": "string",
+                    "description": (
+                        "Search type. 'auto' (default) lets Exa choose, 'neural' uses "
+                        "embedding similarity, 'fast' is latency-optimized."
+                    ),
+                    "enum": sorted(_VALID_SEARCH_TYPES),
+                    "default": "auto",
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Optional content category filter.",
+                    "enum": sorted(_VALID_CATEGORIES),
+                },
+                "include_domains": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Restrict results to these domains.",
+                },
+                "exclude_domains": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Exclude results from these domains.",
+                },
+                "include_text": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Result text must contain these strings.",
+                },
+                "exclude_text": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Result text must not contain these strings.",
+                },
+                "start_published_date": {
+                    "type": "string",
+                    "description": "ISO 8601 lower bound on publish date.",
+                },
+                "end_published_date": {
+                    "type": "string",
+                    "description": "ISO 8601 upper bound on publish date.",
+                },
+                "content_mode": {
+                    "type": "string",
+                    "description": (
+                        "Which page contents to fetch alongside results. "
+                        "'highlights' (default) returns short matching passages; "
+                        "'summary' returns an LLM-generated summary; "
+                        "'text' returns full page text; 'all' returns everything."
+                    ),
+                    "enum": ["highlights", "summary", "text", "all", "none"],
+                    "default": "highlights",
+                },
+                "summary_query": {
+                    "type": "string",
+                    "description": "Optional guidance for the summary content type.",
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def execute(self, params: Dict[str, Any]) -> ToolResult:
+        query = (params.get("query") or "").strip()
+        if not query:
+            return ToolResult(success=False, output="", error="Missing required parameter: query")
+
+        if not self.api_key:
+            return ToolResult(
+                success=False,
+                output="",
+                error=(
+                    "Exa API key not configured. "
+                    "Set EXA_API_KEY environment variable to enable Exa search."
+                ),
+            )
+
+        num_results = int(params.get("num_results", 5))
+        num_results = max(1, min(num_results, 25))
+
+        search_type = params.get("type", "auto")
+        if search_type not in _VALID_SEARCH_TYPES:
+            return ToolResult(
+                success=False,
+                output="",
+                error=f"Invalid search type: {search_type}",
+            )
+
+        category = params.get("category")
+        if category is not None and category not in _VALID_CATEGORIES:
+            return ToolResult(
+                success=False,
+                output="",
+                error=f"Invalid category: {category}",
+            )
+
+        request_kwargs: Dict[str, Any] = {
+            "query": query,
+            "num_results": num_results,
+            "type": search_type,
+        }
+        if category:
+            request_kwargs["category"] = category
+        for key in (
+            "include_domains",
+            "exclude_domains",
+            "include_text",
+            "exclude_text",
+            "start_published_date",
+            "end_published_date",
+        ):
+            value = params.get(key)
+            if value:
+                request_kwargs[key] = value
+
+        content_kwargs = self._build_content_kwargs(
+            mode=params.get("content_mode", "highlights"),
+            summary_query=params.get("summary_query"),
+        )
+        request_kwargs.update(content_kwargs)
+
+        logger.info("exa_search", query=query, num_results=num_results, type=search_type)
+
+        try:
+            response = await asyncio.wait_for(
+                asyncio.to_thread(self._search_sync, request_kwargs),
+                timeout=self.timeout,
+            )
+        except asyncio.TimeoutError:
+            return ToolResult(
+                success=False, output="", error=f"Exa search timed out after {self.timeout}s"
+            )
+        except ImportError as e:
+            logger.error("exa_search_import_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                output="",
+                error=(
+                    "exa-py is not installed. Install it with: pip install exa-py>=2.0.0"
+                ),
+            )
+        except Exception as e:
+            logger.error("exa_search_failed", error=str(e))
+            return ToolResult(success=False, output="", error=f"Exa search error: {e}")
+
+        raw_results = getattr(response, "results", None)
+        if raw_results is None and isinstance(response, dict):
+            raw_results = response.get("results", [])
+        raw_results = raw_results or []
+
+        results = [ExaSearchResult.from_api(item) for item in raw_results]
+        output = _format_results(query, results)
+
+        logger.info("exa_search_success", query=query, results_count=len(results))
+
+        return ToolResult(
+            success=True,
+            output=output,
+            metadata={
+                "query": query,
+                "results_count": len(results),
+                "type": search_type,
+            },
+        )
+
+    def _build_content_kwargs(
+        self, mode: str, summary_query: Optional[str]
+    ) -> Dict[str, Any]:
+        """Map the user-facing content_mode to exa-py kwargs.
+
+        Exa allows multiple content types per request; 'all' enables every
+        type so the caller can pick whichever is most useful per result.
+        """
+        mode = (mode or "highlights").lower()
+        kwargs: Dict[str, Any] = {}
+
+        if mode == "none":
+            return kwargs
+
+        if mode in ("highlights", "all"):
+            kwargs["highlights"] = True
+        if mode in ("text", "all"):
+            kwargs["text"] = True
+        if mode in ("summary", "all"):
+            kwargs["summary"] = (
+                {"query": summary_query} if summary_query else True
+            )
+
+        return kwargs
+
+    def _search_sync(self, request_kwargs: Dict[str, Any]) -> Any:
+        """Run the blocking exa-py call. Executed inside a worker thread."""
+        from exa_py import Exa  # imported lazily so the dep is optional at import time
+
+        client = Exa(api_key=self.api_key)
+        # Tag requests so Exa can attribute usage to this integration.
+        try:
+            client.headers["x-exa-integration"] = self.INTEGRATION_NAME
+        except AttributeError:
+            pass
+
+        return client.search_and_contents(**request_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "beautifulsoup4>=4.12.0",
     "prompt-toolkit>=3.0.0",
+    "exa-py>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_exa_tool.py
+++ b/tests/test_exa_tool.py
@@ -1,0 +1,270 @@
+"""Tests for the Exa search tool."""
+
+import sys
+import types
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from omniagent.tools.exa_tool import (
+    ExaSearchResult,
+    ExaSearchTool,
+    _format_results,
+)
+
+
+def _fake_search_response() -> Any:
+    """Build a fake response object shaped like exa-py's SearchResponse."""
+    results = [
+        types.SimpleNamespace(
+            title="Anthropic",
+            url="https://anthropic.com",
+            published_date="2025-01-15T00:00:00Z",
+            author="Anthropic",
+            text="Anthropic is an AI safety company.",
+            highlights=["AI safety company", "Claude is a chatbot"],
+            summary="Anthropic builds Claude.",
+            score=0.91,
+        ),
+        types.SimpleNamespace(
+            title="Exa",
+            url="https://exa.ai",
+            published_date=None,
+            author=None,
+            text=None,
+            highlights=[],
+            summary=None,
+            score=0.7,
+        ),
+    ]
+    return types.SimpleNamespace(results=results)
+
+
+class _FakeExa:
+    """Stand-in for exa_py.Exa used to capture calls and headers."""
+
+    instances: List["_FakeExa"] = []
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.headers: Dict[str, str] = {}
+        self.calls: List[Dict[str, Any]] = []
+        _FakeExa.instances.append(self)
+
+    def search_and_contents(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return _fake_search_response()
+
+
+@pytest.fixture(autouse=True)
+def _install_fake_exa(monkeypatch: pytest.MonkeyPatch):
+    """Inject a fake exa_py module so the lazy import resolves to our stub."""
+    _FakeExa.instances = []
+    fake_module = types.ModuleType("exa_py")
+    fake_module.Exa = _FakeExa  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "exa_py", fake_module)
+    yield
+
+
+def test_search_result_from_dict_shape():
+    item = {
+        "title": "Hello",
+        "url": "https://example.com",
+        "publishedDate": "2025-04-01",
+        "highlights": ["a", "b"],
+    }
+    parsed = ExaSearchResult.from_api(item)
+    assert parsed.title == "Hello"
+    assert parsed.url == "https://example.com"
+    assert parsed.published_date == "2025-04-01"
+    assert parsed.highlights == ["a", "b"]
+
+
+def test_snippet_prefers_highlights_then_summary_then_text():
+    only_text = ExaSearchResult(title="t", url="u", text="full text body")
+    only_summary = ExaSearchResult(title="t", url="u", summary="a summary")
+    with_highlights = ExaSearchResult(
+        title="t", url="u", highlights=["first hit", "second hit"], summary="x", text="y"
+    )
+    assert only_text.snippet() == "full text body"
+    assert only_summary.snippet() == "a summary"
+    assert with_highlights.snippet().startswith("first hit")
+
+
+def test_format_results_handles_empty():
+    out = _format_results("nothing", [])
+    assert "No results" in out
+
+
+def test_format_results_renders_url_and_snippet():
+    results = [
+        ExaSearchResult(
+            title="Anthropic",
+            url="https://anthropic.com",
+            highlights=["AI safety"],
+        )
+    ]
+    out = _format_results("anthropic", results)
+    assert "Anthropic" in out
+    assert "https://anthropic.com" in out
+    assert "AI safety" in out
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_error_when_api_key_missing(monkeypatch):
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    tool = ExaSearchTool()
+    result = await tool.execute({"query": "anthropic"})
+    assert result.success is False
+    assert "EXA_API_KEY" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_blank_query(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+    tool = ExaSearchTool()
+    result = await tool.execute({"query": "   "})
+    assert result.success is False
+    assert "query" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_calls_exa_with_expected_kwargs_and_header(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+    tool = ExaSearchTool()
+
+    result = await tool.execute(
+        {
+            "query": "anthropic",
+            "num_results": 3,
+            "type": "neural",
+            "category": "company",
+            "include_domains": ["anthropic.com"],
+            "exclude_domains": ["example.com"],
+            "start_published_date": "2024-01-01",
+            "content_mode": "all",
+            "summary_query": "What does the company do?",
+        }
+    )
+
+    assert result.success is True
+    assert "Anthropic" in result.output
+    assert "https://anthropic.com" in result.output
+    assert result.metadata["results_count"] == 2
+    assert result.metadata["type"] == "neural"
+
+    assert len(_FakeExa.instances) == 1
+    fake = _FakeExa.instances[0]
+    assert fake.api_key == "test-key"
+    assert fake.headers.get("x-exa-integration") == "omniagent"
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["query"] == "anthropic"
+    assert call["num_results"] == 3
+    assert call["type"] == "neural"
+    assert call["category"] == "company"
+    assert call["include_domains"] == ["anthropic.com"]
+    assert call["exclude_domains"] == ["example.com"]
+    assert call["start_published_date"] == "2024-01-01"
+    # content_mode='all' should turn on every content type
+    assert call["highlights"] is True
+    assert call["text"] is True
+    assert call["summary"] == {"query": "What does the company do?"}
+
+
+@pytest.mark.asyncio
+async def test_execute_clamps_num_results(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+    tool = ExaSearchTool()
+    await tool.execute({"query": "x", "num_results": 999})
+    call = _FakeExa.instances[0].calls[0]
+    assert call["num_results"] == 25
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_invalid_search_type(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+    tool = ExaSearchTool()
+    result = await tool.execute({"query": "x", "type": "keyword"})
+    assert result.success is False
+    assert "Invalid search type" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_handles_partial_results_without_highlights(monkeypatch):
+    """A result with only a summary should still produce a usable snippet."""
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+    summary_only = types.SimpleNamespace(
+        title="Summary Only",
+        url="https://s.example/",
+        published_date=None,
+        author=None,
+        text=None,
+        highlights=[],
+        summary="This is only a summary.",
+        score=0.5,
+    )
+
+    class _SummaryOnly(_FakeExa):
+        def search_and_contents(self, **kwargs):
+            self.calls.append(kwargs)
+            return types.SimpleNamespace(results=[summary_only])
+
+    fake_module = types.ModuleType("exa_py")
+    fake_module.Exa = _SummaryOnly  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "exa_py", fake_module)
+
+    tool = ExaSearchTool()
+    result = await tool.execute({"query": "x", "content_mode": "summary"})
+    assert result.success is True
+    assert "This is only a summary." in result.output
+
+
+@pytest.mark.asyncio
+async def test_execute_surface_sdk_exceptions(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+
+    class _Boom(_FakeExa):
+        def search_and_contents(self, **kwargs):
+            raise RuntimeError("upstream 500")
+
+    fake_module = types.ModuleType("exa_py")
+    fake_module.Exa = _Boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "exa_py", fake_module)
+
+    tool = ExaSearchTool()
+    result = await tool.execute({"query": "x"})
+    assert result.success is False
+    assert "upstream 500" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_reports_missing_sdk(monkeypatch):
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
+    monkeypatch.delitem(sys.modules, "exa_py", raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "exa_py":
+            raise ImportError("No module named 'exa_py'")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        tool = ExaSearchTool()
+        result = await tool.execute({"query": "x"})
+    assert result.success is False
+    assert "exa-py" in (result.error or "")
+
+
+def test_schema_advertises_required_fields():
+    schema = ExaSearchTool().get_schema()
+    assert schema["name"] == "exa_search"
+    assert "query" in schema["parameters"]["required"]
+    props = schema["parameters"]["properties"]
+    assert "num_results" in props
+    assert "include_domains" in props
+    assert "content_mode" in props


### PR DESCRIPTION
## Summary

Adds an Exa AI-powered search tool alongside the existing Brave-based `web_search`, giving the agent a second search backend with embedding/neural retrieval, category and domain filters, date ranges, and per-page content (highlights, summary, full text).

- New tool `exa_search` (`omniagent/tools/exa_tool.py`) following the existing `Tool` / `ToolResult` pattern
- Wired into `ReflexionAgent`, the `web` policy group, and the skill-evolution name map
- Uses the official `exa-py` SDK via `asyncio.to_thread` so the async tool layer stays non-blocking
- Reads `EXA_API_KEY` from the environment, matching the `BRAVE_API_KEY` pattern used by `web_search`
- Adds a `tests/` directory with unit tests for parsing, snippet fallback, argument forwarding, clamping, missing-key behavior, and SDK error surfacing

## Why

`web_search` currently only supports Brave. Exa returns neural/embedding-ranked results with optional page contents in a single call, which is a good fit for the deep-research workflows OmniAgent advertises (multi-source web search, knowledge cross-validation). Adding it as an additional tool lets the agent pick whichever backend is more appropriate for the task without removing the existing Brave integration.

## Usage

```python
from omniagent.tools import ExaSearchTool

tool = ExaSearchTool()
result = await tool.execute({
    "query": "latest research on multi-agent reflexion",
    "num_results": 5,
    "type": "neural",
    "category": "research paper",
    "content_mode": "highlights",
    "start_published_date": "2024-01-01",
})
print(result.output)
```

Exposed parameters: `query`, `num_results`, `type` (`auto`/`neural`/`fast`/`deep`/...), `category`, `include_domains`, `exclude_domains`, `include_text`, `exclude_text`, `start_published_date`, `end_published_date`, `content_mode` (`highlights`/`summary`/`text`/`all`/`none`), `summary_query`.

## Files changed

- `omniagent/tools/exa_tool.py` — new `ExaSearchTool` plus typed `ExaSearchResult` dataclass
- `omniagent/tools/__init__.py` — export `ExaSearchTool`
- `omniagent/agents/reflexion.py` — register the tool in `ReflexionAgent`
- `omniagent/agents/skill_evolution.py` — add `exa_search` to the name map
- `omniagent/security/policy.py` — include `exa_search` in the `web` tool group
- `pyproject.toml` — add `exa-py>=2.0.0` dependency
- `tests/test_exa_tool.py` — unit tests (no network)

## Test plan

- [x] `pytest tests/test_exa_tool.py` — 13 tests pass
- [x] `mypy omniagent/tools/exa_tool.py` — no errors in the new file
- [x] Tool registers without error (`from omniagent.tools import ExaSearchTool`)
- [x] Policy group `web` includes `exa_search`
- [ ] Live API smoke test (requires `EXA_API_KEY`)