### PR TITLE
feat: Add light theme

### DIFF
--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -27,6 +27,28 @@
   --radius: 12px;
   --sidebar-width: 220px;
 }
+[data-theme="light"] {
+  --bg-primary: #f5f5f8;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #eef0f5;
+  --bg-hover: #e4e6ed;
+  --bg-input: #ffffff;
+  --text-primary: #1a1a2e;
+  --text-secondary: #555570;
+  --text-dim: #9090a8;
+  --accent: #6c63ff;
+  --accent-hover: #5a52d5;
+  --accent-soft: rgba(108,99,255,0.08);
+  --border: #dddde8;
+  --user-bg: #6c63ff;
+  --error-bg: #fff0f0;
+  --error-text: #d32f2f;
+  --success: #2e8b7a;
+  --warning: #b8860b;
+  --danger: #d32f2f;
+  --radius: 12px;
+  --sidebar-width: 220px;
+}
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
@@ -103,6 +125,9 @@ body {
   font-size: 11px;
   color: var(--text-dim);
   margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .sidebar-footer .status {
   display: flex;
@@ -114,6 +139,21 @@ body {
   background: var(--success);
 }
 .sidebar-footer .status-dot.disconnected { background: var(--error-text); }
+.sidebar-footer .theme-toggle {
+  width: 24px; height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: center;
+  border-radius: 5px;
+  color: var(--text-dim);
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+.sidebar-footer .theme-toggle:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 /* ── Main area ──────────────────────── */
 #main {
@@ -625,6 +665,7 @@ body {
       <span class="status-dot" id="status-dot"></span>
       <span id="status-text">Connecting...</span>
     </div>
+    <button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme" id="theme-icon">&#x2600;</button>
   </div>
 </div>
 
@@ -1459,6 +1500,23 @@ const panels = {
     },
   },
 };
+
+// ── Theme ───────────────────────────
+function getTheme() {
+  return document.documentElement.getAttribute('data-theme') || 'dark';
+}
+function setTheme(t) {
+  document.documentElement.setAttribute('data-theme', t);
+  document.getElementById('theme-icon').innerHTML = t === 'light' ? '&#x263D;' : '&#x2600;';
+  localStorage.setItem('omniagent-theme', t);
+}
+function toggleTheme() { setTheme(getTheme() === 'dark' ? 'light' : 'dark'); }
+
+// Apply saved theme on startup (default dark)
+(function initTheme() {
+  const saved = localStorage.getItem('omniagent-theme');
+  if (saved) setTheme(saved);
+})();
 
 // ── Init ────────────────────────────
 connect();


### PR DESCRIPTION
## What & Why

This PR focuses on optimizing the front-end visual experience by adding a light mode to the Web UI and enabling free switching between dark and light themes. It caters to different user preferences and usage scenarios, enhancing the overall interface aesthetics and readability.

## Changes
- Add a new light theme color scheme, compatible with all UI elements of the Web UI
- Implement light/dark theme switching functionality, supporting manual switching by users
- Keep the original dark theme fully functional without any compatibility issues
- Unify style specifications, ensuring no lag during switching and no layout distortion

## User Impact
- Users can freely switch between light and dark themes according to their preferences
- Clearer display in strong light environments, providing a more comfortable visual experience
- No impact on existing functions, ensuring a seamless upgrade