### PR TITLE
feat: Add usage dashboard & Optimize Provider Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ MEMORY.md
 # Dev artifacts
 test-project/
 clean_test_project*.sh
+# Local runtime config (may contain API keys)
+config.yaml

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ agent:
   reflexion_enabled: true
 ```
 
+> Built-in provider keys (`deepseek`, `openai`, etc.) infer their API type from the key. Named OpenAI-compatible providers should set `api_type: openai-compatible`.
+>
 > Full configuration reference: [docs.omniagent.dev](https://docs.omniagent.dev) *(coming soon)*
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -125,6 +125,8 @@ agent:
   reflexion_enabled: true
 ```
 
+> 内置 Provider key（如 `deepseek`、`openai`）会默认推断同名 API type；命名的 OpenAI-compatible Provider 才需要设置 `api_type: openai-compatible`。
+>
 > 完整配置参考：[docs.omniagent.dev](https://docs.omniagent.dev) *(即将上线)*
 
 ---

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,85 @@
+# OmniAgent runtime config template used by both local Python and Docker deployments.
+#
+# This file is safe to commit because secrets are referenced through environment
+# variables. Do not put real API keys in this example file.
+#
+# Docker Compose mode:
+#   cp config.example.yaml config.yaml
+#   edit config.yaml on the VM/host
+#   docker-compose.yml bind-mounts ./config.yaml to /home/omniagent/.omniagent/config.yaml:ro
+#   OmniAgent reads its default config path in Docker mode
+#   ensure config.yaml is readable by UID 10001
+#   click "Reload from Disk" in the Web UI after editing config.yaml
+#
+# Local Python mode examples:
+#   omniagent --config config.yaml serve --host 127.0.0.1 --port 18790
+#   mkdir -p $HOME/.omniagent && cp config.example.yaml $HOME/.omniagent/config.yaml
+#   omniagent serve
+
+version: "0.1.0"
+work_dir: .
+
+providers:
+  deepseek:
+    api_key: ${DEEPSEEK_API_KEY:-}
+    model_id: deepseek-chat
+    api_url: https://api.deepseek.com/v1
+    provider_name: deepseek
+
+  openai:
+    api_key: ${OPENAI_API_KEY:-}
+    model_id: gpt-4o
+    api_url: https://api.openai.com/v1
+    provider_name: openai
+
+  anthropic:
+    api_key: ${ANTHROPIC_API_KEY:-}
+    model_id: claude-sonnet-4-20250514
+    api_url: null
+    provider_name: anthropic
+
+  ollama:
+    api_key: ""
+    model_id: llama3
+    api_url: null
+    provider_name: ollama
+
+  # OpenAI-compatible custom endpoint example.
+  custom:
+    api_key: ${CUSTOM_API_KEY:-}
+    model_id: default
+    api_url: ${CUSTOM_API_URL:-http://host.docker.internal:8000/v1}
+    provider_name: custom
+
+agent:
+  # Change this to one of: deepseek, openai, anthropic, ollama, custom.
+  model_provider: deepseek
+  model_id: deepseek-chat
+  api_url: null
+  temperature: 0.7
+  max_tokens: 4096
+  max_iterations: 10
+  reflexion_enabled: true
+  reflexion_max_attempts: 2
+
+gateway:
+  # Dockerfile passes --host 0.0.0.0 at startup for container networking.
+  # Keep this localhost value for local Python runs unless you need otherwise.
+  host: 127.0.0.1
+  port: 18790
+  session_timeout: 3600
+
+tools:
+  # minimal | coding | messaging | full
+  profile: coding
+
+usage:
+  pricing_catalog_enabled: true
+  pricing_catalog_url: https://models.dev/api.json
+  pricing_cache_ttl_seconds: 900
+  pricing_request_timeout_seconds: 2.0
+
+enable_progressive_loading: true
+enable_parallel_execution: true
+enable_security_guard: true
+enable_self_improving: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,20 +1,12 @@
-# OmniAgent runtime config template used by both local Python and Docker deployments.
+# OmniAgent runtime config template.
 #
 # This file is safe to commit because secrets are referenced through environment
 # variables. Do not put real API keys in this example file.
 #
-# Docker Compose mode:
-#   cp config.example.yaml config.yaml
-#   edit config.yaml on the VM/host
-#   docker-compose.yml bind-mounts ./config.yaml to /home/omniagent/.omniagent/config.yaml:ro
-#   OmniAgent reads its default config path in Docker mode
-#   ensure config.yaml is readable by UID 10001
-#   click "Reload from Disk" in the Web UI after editing config.yaml
-#
 # Local Python mode examples:
-#   omniagent --config config.yaml serve --host 127.0.0.1 --port 18790
 #   mkdir -p $HOME/.omniagent && cp config.example.yaml $HOME/.omniagent/config.yaml
 #   omniagent serve
+#   omniagent --config config.yaml serve --host 127.0.0.1 --port 18790
 
 version: "0.1.0"
 work_dir: .
@@ -48,7 +40,11 @@ providers:
   custom:
     api_key: ${CUSTOM_API_KEY:-}
     model_id: default
-    api_url: ${CUSTOM_API_URL:-http://host.docker.internal:8000/v1}
+    api_url: ${CUSTOM_API_URL:-http://localhost:8000/v1}
+    # Usage/pricing provider identity. The pricing rule key is
+    # provider_name/model_id (for example: custom/default).
+    # Use a known catalog provider such as openai only when this endpoint truly
+    # proxies that provider; otherwise keep custom and add a pricing override.
     provider_name: custom
 
 agent:
@@ -63,8 +59,7 @@ agent:
   reflexion_max_attempts: 2
 
 gateway:
-  # Dockerfile passes --host 0.0.0.0 at startup for container networking.
-  # Keep this localhost value for local Python runs unless you need otherwise.
+  # Keep localhost unless you intentionally expose the gateway behind your own protection.
   host: 127.0.0.1
   port: 18790
   session_timeout: 3600
@@ -74,10 +69,22 @@ tools:
   profile: coding
 
 usage:
+  # Estimated costs use manual provider/model rules first, then the remote
+  # models.dev catalog. If provider/model is not found, bare model_id fallback is
+  # used only when the model_id has one unambiguous price in the catalog.
   pricing_catalog_enabled: true
   pricing_catalog_url: https://models.dev/api.json
   pricing_cache_ttl_seconds: 900
   pricing_request_timeout_seconds: 2.0
+  # Manual rules are USD per million tokens and should be keyed by provider/model_id.
+  # The provider part is providers.<name>.provider_name when set, otherwise <name>.
+  pricing_overrides: {}
+  # Example:
+  # pricing_overrides:
+  #   custom/default:
+  #     input: 0.15
+  #     output: 0.60
+  #     cache_read: 0.075
 
 enable_progressive_loading: true
 enable_parallel_execution: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,43 +12,40 @@ version: "0.1.0"
 work_dir: .
 
 providers:
+  # The provider map key is the provider identity used in Settings, usage rows,
+  # and pricing_overrides keys. Built-in keys such as deepseek/openai infer the
+  # same api_type automatically; only named OpenAI-compatible providers need api_type: openai-compatible.
   deepseek:
     api_key: ${DEEPSEEK_API_KEY:-}
     model_id: deepseek-chat
     api_url: https://api.deepseek.com/v1
-    provider_name: deepseek
 
   openai:
     api_key: ${OPENAI_API_KEY:-}
     model_id: gpt-4o
     api_url: https://api.openai.com/v1
-    provider_name: openai
 
   anthropic:
     api_key: ${ANTHROPIC_API_KEY:-}
     model_id: claude-sonnet-4-20250514
     api_url: null
-    provider_name: anthropic
 
   ollama:
     api_key: ""
     model_id: llama3
     api_url: null
-    provider_name: ollama
 
-  # OpenAI-compatible custom endpoint example.
-  custom:
+  # OpenAI-compatible endpoint example. Add more named entries with
+  # api_type: openai-compatible to connect multiple OpenAI-compatible providers.
+  my-openai-compatible:
+    api_type: openai-compatible
     api_key: ${CUSTOM_API_KEY:-}
     model_id: default
     api_url: ${CUSTOM_API_URL:-http://localhost:8000/v1}
-    # Usage/pricing provider identity. The pricing rule key is
-    # provider_name/model_id (for example: custom/default).
-    # Use a known catalog provider such as openai only when this endpoint truly
-    # proxies that provider; otherwise keep custom and add a pricing override.
-    provider_name: custom
 
 agent:
-  # Change this to one of: deepseek, openai, anthropic, ollama, custom.
+  # Select a provider key from the providers map, for example: deepseek, openai,
+  # anthropic, ollama, or my-openai-compatible.
   model_provider: deepseek
   model_id: deepseek-chat
   api_url: null
@@ -76,12 +73,11 @@ usage:
   pricing_catalog_url: https://models.dev/api.json
   pricing_cache_ttl_seconds: 900
   pricing_request_timeout_seconds: 2.0
-  # Manual rules are USD per million tokens and should be keyed by provider/model_id.
-  # The provider part is providers.<name>.provider_name when set, otherwise <name>.
+  # Manual rules are USD per million tokens and should be keyed by provider_key/model_id.
   pricing_overrides: {}
   # Example:
   # pricing_overrides:
-  #   custom/default:
+  #   my-openai-compatible/default:
   #     input: 0.15
   #     output: 0.60
   #     cache_read: 0.075

--- a/index.html
+++ b/index.html
@@ -800,8 +800,8 @@
                     <svg class="faq-chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
                 </summary>
                 <div class="faq-answer">
-                    <p data-lang="en">9 backends: DeepSeek, OpenAI, Anthropic, Ollama, Google Gemini, OpenRouter, vLLM, SGLang, and Custom (any OpenAI-compatible endpoint). All support native function calling. You can switch providers on the fly with <code>--provider</code> flag or configure different models per agent.</p>
-                    <p data-lang="cn">9 个后端：DeepSeek、OpenAI、Anthropic、Ollama、Google Gemini、OpenRouter、vLLM、SGLang 和 Custom（任何 OpenAI 兼容端点）。全部支持原生 function calling。可以通过 <code>--provider</code> 参数随时切换，或为不同 Agent 配置不同模型。</p>
+                    <p data-lang="en">9 backends: DeepSeek, OpenAI, Anthropic, Ollama, Google Gemini, OpenRouter, vLLM, SGLang, and OpenAI-compatible endpoints. All support native function calling. You can switch providers on the fly with <code>--provider</code> flag or configure different models per agent.</p>
+                    <p data-lang="cn">9 个后端：DeepSeek、OpenAI、Anthropic、Ollama、Google Gemini、OpenRouter、vLLM、SGLang 和 OpenAI-compatible 端点。全部支持原生 function calling。可以通过 <code>--provider</code> 参数随时切换，或为不同 Agent 配置不同模型。</p>
                 </div>
             </details>
             <details class="faq-item">

--- a/omniagent/agents/llm.py
+++ b/omniagent/agents/llm.py
@@ -274,7 +274,7 @@ class DeepSeekLLMProvider(LLMProvider):
                     content=self.strip_thinking(content),
                     finish_reason=finish_reason,
                     usage=usage,
-                    metadata={"model": self.model},
+                    metadata={"model": self.model, "provider": "deepseek"},
                     tool_calls=tool_calls,
                 )
 
@@ -481,10 +481,25 @@ class OpenAILLMProvider(LLMProvider):
 
             usage = {}
             if response.usage:
+                prompt_tokens = response.usage.prompt_tokens or 0
+                completion_tokens = response.usage.completion_tokens or 0
+                prompt_details = getattr(response.usage, "prompt_tokens_details", None)
+                cached_tokens = 0
+                if prompt_details:
+                    if isinstance(prompt_details, dict):
+                        cached_tokens = prompt_details.get("cached_tokens", 0) or 0
+                    else:
+                        cached_tokens = getattr(prompt_details, "cached_tokens", 0) or 0
                 usage = {
-                    "prompt_tokens": response.usage.prompt_tokens or 0,
-                    "completion_tokens": response.usage.completion_tokens or 0,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
                     "total_tokens": response.usage.total_tokens or 0,
+                    "input_tokens": prompt_tokens,
+                    "input_tokens_uncached": max(prompt_tokens - cached_tokens, 0),
+                    "cached_tokens": cached_tokens,
+                    "cached_input_tokens": cached_tokens,
+                    "cache_read_input_tokens": cached_tokens,
+                    "output_tokens": completion_tokens,
                 }
 
             logger.info(
@@ -707,10 +722,20 @@ class AnthropicLLMProvider(LLMProvider):
 
             usage = {}
             if response.usage:
+                input_tokens = response.usage.input_tokens or 0
+                output_tokens = response.usage.output_tokens or 0
+                cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+                cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
                 usage = {
-                    "prompt_tokens": response.usage.input_tokens or 0,
-                    "completion_tokens": response.usage.output_tokens or 0,
-                    "total_tokens": (response.usage.input_tokens or 0) + (response.usage.output_tokens or 0),
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens,
+                    "input_tokens": input_tokens,
+                    "input_tokens_uncached": input_tokens,
+                    "cache_creation_input_tokens": cache_creation_tokens,
+                    "cache_read_input_tokens": cache_read_tokens,
+                    "cached_input_tokens": cache_read_tokens,
+                    "output_tokens": output_tokens,
                 }
 
             logger.info(
@@ -847,7 +872,7 @@ class OllamaLLMProvider(LLMProvider):
                     usage = data.get("usage", {})
                     tool_calls = message.get("tool_calls")
                     logger.info("ollama_response", content_length=len(content), finish_reason=finish_reason, has_tool_calls=tool_calls is not None, usage=usage)
-                    return LLMResponse(content=content, finish_reason=finish_reason, usage=usage, metadata={"model": self.model}, tool_calls=tool_calls)
+                    return LLMResponse(content=content, finish_reason=finish_reason, usage=usage, metadata={"model": self.model, "provider": "ollama"}, tool_calls=tool_calls)
         except aiohttp.ClientConnectorError:
             raise RuntimeError(f"Ollama not reachable at {self.api_url}. Make sure Ollama is running.")
 
@@ -947,12 +972,21 @@ class GoogleGeminiLLMProvider(LLMProvider):
                         }]
             usage = {}
             if response.usage_metadata:
+                prompt_tokens = response.usage_metadata.prompt_token_count or 0
+                completion_tokens = response.usage_metadata.candidates_token_count or 0
+                cached_tokens = getattr(response.usage_metadata, "cached_content_token_count", 0) or 0
                 usage = {
-                    "prompt_tokens": response.usage_metadata.prompt_token_count or 0,
-                    "completion_tokens": response.usage_metadata.candidates_token_count or 0,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
                     "total_tokens": response.usage_metadata.total_token_count or 0,
+                    "input_tokens": prompt_tokens,
+                    "input_tokens_uncached": max(prompt_tokens - cached_tokens, 0),
+                    "cached_tokens": cached_tokens,
+                    "cached_input_tokens": cached_tokens,
+                    "cache_read_input_tokens": cached_tokens,
+                    "output_tokens": completion_tokens,
                 }
-            return LLMResponse(content=content, finish_reason="stop", usage=usage, metadata={"model": self.model}, tool_calls=tool_calls)
+            return LLMResponse(content=content, finish_reason="stop", usage=usage, metadata={"model": self.model, "provider": "gemini"}, tool_calls=tool_calls)
         except Exception as e:
             logger.error("gemini_error", error=str(e))
             raise RuntimeError(f"Gemini request failed: {e}")
@@ -1055,10 +1089,25 @@ class LocalInferenceLLMProvider(OpenAILLMProvider):
 
             usage = {}
             if response.usage:
+                prompt_tokens = response.usage.prompt_tokens or 0
+                completion_tokens = response.usage.completion_tokens or 0
+                prompt_details = getattr(response.usage, "prompt_tokens_details", None)
+                cached_tokens = 0
+                if prompt_details:
+                    if isinstance(prompt_details, dict):
+                        cached_tokens = prompt_details.get("cached_tokens", 0) or 0
+                    else:
+                        cached_tokens = getattr(prompt_details, "cached_tokens", 0) or 0
                 usage = {
-                    "prompt_tokens": response.usage.prompt_tokens or 0,
-                    "completion_tokens": response.usage.completion_tokens or 0,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
                     "total_tokens": response.usage.total_tokens or 0,
+                    "input_tokens": prompt_tokens,
+                    "input_tokens_uncached": max(prompt_tokens - cached_tokens, 0),
+                    "cached_tokens": cached_tokens,
+                    "cached_input_tokens": cached_tokens,
+                    "cache_read_input_tokens": cached_tokens,
+                    "output_tokens": completion_tokens,
                 }
 
             # Extract per-token logprobs

--- a/omniagent/agents/llm.py
+++ b/omniagent/agents/llm.py
@@ -1018,7 +1018,7 @@ class LocalInferenceLLMProvider(OpenAILLMProvider):
     This provider extends OpenAILLMProvider to collect per-token logprobs,
     which are essential for GRPO/PPO importance sampling.
 
-    Only used when model_provider is "vllm" or "sglang".
+    Only used when api_type is "vllm" or "sglang".
     """
 
     def __init__(
@@ -1126,20 +1126,27 @@ class LocalInferenceLLMProvider(OpenAILLMProvider):
                         ]
                     logprobs.append(entry)
 
-            provider_name = "vllm"
+            metadata_provider = "vllm"
             if self.base_url and "sglang" in self.base_url.lower():
-                provider_name = "sglang"
+                metadata_provider = "sglang"
 
             return LLMResponse(
                 content=content,
                 finish_reason=choice.finish_reason,
                 usage=usage,
                 tool_calls=tool_calls,
-                metadata={"model": self.model, "provider": provider_name},
+                metadata={"model": self.model, "provider": metadata_provider},
                 logprobs=logprobs,
             )
         finally:
             await client.close()
+
+
+def _normalize_provider_api_type(provider: str) -> str:
+    normalized = str(provider or "deepseek").strip().lower()
+    if normalized in {"custom", "openai_compatible"}:
+        return "openai-compatible"
+    return normalized
 
 
 def create_llm_provider(
@@ -1148,8 +1155,12 @@ def create_llm_provider(
     model: str = "",
     api_url: str = None,
 ) -> LLMProvider:
-    """Factory function to create an LLM provider instance."""
-    provider = provider.lower()
+    """Factory function to create an LLM provider instance.
+
+    The provider argument is an implementation type, not necessarily the
+    user-facing provider key from config.providers.
+    """
+    provider = _normalize_provider_api_type(provider)
 
     if provider == "deepseek":
         return DeepSeekLLMProvider(api_key=api_key, model=model or "deepseek-chat", api_url=api_url or "https://api.deepseek.com/v1")
@@ -1170,9 +1181,9 @@ def create_llm_provider(
             api_key=api_key or "not-needed",
             model=model or "default",
         )
-    elif provider == "custom":
+    elif provider == "openai-compatible":
         if not api_url:
-            raise ValueError("Custom provider requires api_url to be set (e.g. in config: providers.custom.api_url)")
+            raise ValueError("Provider api_type=openai-compatible requires api_url to be set")
         return OpenAILLMProvider(api_key=api_key, model=model or "default", api_url=api_url)
     else:
-        raise ValueError(f"Unknown LLM provider: {provider}")
+        raise ValueError(f"Unknown LLM provider api_type: {provider}")

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -85,7 +85,7 @@ class ReflexionAgent(Agent):
         # Create LLM provider
         if llm_provider is None:
             # Resolve provider-specific overrides
-            provider_api_url = config.agent.api_url
+            provider_api_url = config.agent.api_url or ""
             provider_api_key = ""
 
             if provider_cfg:
@@ -330,6 +330,119 @@ class ReflexionAgent(Agent):
             native_fc=self.llm.supports_native_function_calling,
         )
 
+    def _build_llm_from_config(self, config: OmniAgentConfig) -> Tuple[LLMProvider, str, str]:
+        """Create an LLM provider from the active config and resolve provider presets."""
+        provider_name = config.agent.model_provider
+        provider_cfg = config.providers.get(provider_name) if config.providers else None
+        usage_provider_name = provider_name
+        provider_model = config.agent.model_id
+
+        if provider_cfg:
+            if provider_cfg.provider_name:
+                usage_provider_name = provider_cfg.provider_name
+            if provider_cfg.model_id:
+                provider_model = provider_cfg.model_id
+
+        provider_api_url = config.agent.api_url or ""
+        provider_api_key = ""
+        if provider_cfg:
+            if provider_cfg.api_url:
+                provider_api_url = provider_cfg.api_url
+            provider_api_key = provider_cfg.api_key or ""
+
+        if not provider_api_key:
+            provider_api_key = config.api_key or config.openai_api_key or ""
+
+        config.agent.model_id = provider_model
+
+        llm_provider = create_llm_provider(
+            provider=provider_name,
+            api_key=provider_api_key,
+            model=provider_model,
+            api_url=provider_api_url,
+        )
+        return llm_provider, usage_provider_name, provider_model
+
+    def apply_config(self, config: OmniAgentConfig) -> None:
+        """Apply a reloaded config to the running agent without replacing the object."""
+        llm_provider, usage_provider_name, provider_model = self._build_llm_from_config(config)
+
+        self.config = config
+        self.max_iterations = config.agent.max_iterations
+        self.usage_provider_name = usage_provider_name
+        self.usage_model_id = provider_model
+        self.llm = cast(LLMProvider, UsageTrackingLLMProvider(
+            llm_provider,
+            recorder=self.usage_recorder,
+            default_provider=self.usage_provider_name,
+            default_model=self.usage_model_id,
+        ))
+
+        resolved_window = resolve_context_window_size(
+            config.agent.model_id,
+            config.agent.context_window_size,
+        )
+        self.context_manager.context_window_size = resolved_window
+        self.context_manager.llm = self.llm if config.agent.compaction_enabled else None
+        self.context_assembler = ContextAssembler(
+            token_budget=int(resolved_window * config.agent.system_prompt_token_ratio)
+        )
+
+        memory_api_key = config.api_key or config.openai_api_key or ""
+        if self.memory_manager is not None:
+            self.memory_manager.llm = self.llm if config.memory.enabled and memory_api_key else None
+            self.memory_manager.api_key = memory_api_key
+            self.memory_manager.api_url = config.agent.api_url or ""
+            self.memory_manager.model_id = config.agent.model_id
+            self.memory_manager.chunking_tokens = config.memory.chunking_tokens
+            self.memory_manager.chunking_overlap = config.memory.chunking_overlap
+            self.memory_manager.hybrid_enabled = config.memory.hybrid_enabled
+            self.memory_manager.vector_weight = config.memory.hybrid_vector_weight
+            self.memory_manager.text_weight = config.memory.hybrid_text_weight
+            self.memory_manager.query_max_results = config.memory.query_max_results
+            self.memory_manager.query_min_score = config.memory.query_min_score
+            self.memory_manager._vector_available = self.memory_manager.llm is not None
+        elif config.memory.enabled:
+            self.memory_manager = MemorySearchManager(
+                workspace_dir=self.work_dir,
+                store_path=self.work_dir / ".omniagent" / "memory.db",
+                llm_provider=self.llm if memory_api_key else None,
+                api_key=memory_api_key,
+                api_url=config.agent.api_url or "",
+                model_id=config.agent.model_id,
+                chunking_tokens=config.memory.chunking_tokens,
+                chunking_overlap=config.memory.chunking_overlap,
+                hybrid_enabled=config.memory.hybrid_enabled,
+                vector_weight=config.memory.hybrid_vector_weight,
+                text_weight=config.memory.hybrid_text_weight,
+                query_max_results=config.memory.query_max_results,
+                query_min_score=config.memory.query_min_score,
+            )
+            self.register_tool(MemorySearchTool(self.memory_manager))
+            self.register_tool(MemoryGetTool(self.memory_manager))
+
+        self._rl_active = config.agent.model_provider in ("vllm", "sglang")
+        if self._sentinel is not None:
+            self._sentinel._main_agent_config = config.agent
+        if self._guardian is not None:
+            self._guardian._main_agent_config = config.agent
+        if self._skill_evolution is not None:
+            self._skill_evolution.config = config.skill_evolution
+            self._skill_evolution.llm = self.llm
+            self._skill_evolution.analyzer.llm = self.llm
+            self._skill_evolution.evolution_tracker.llm = self.llm
+        if self._context_evolution is not None:
+            self._context_evolution.config = config.context_evolution
+            self._context_evolution.llm = self.llm
+            self._context_evolution.extractor.llm = self.llm
+
+        logger.info(
+            "agent_config_applied",
+            provider=self.usage_provider_name,
+            model=self.usage_model_id,
+            max_iterations=self.max_iterations,
+        )
+
     def steer(self, message: str) -> None:
         """Inject a steering message into the agent's execution loop."""
         self._steering_queue.append(message)
@@ -492,12 +605,13 @@ class ReflexionAgent(Agent):
         if context:
             usage_context.update(context)
         usage_context_token = None
+        reset_usage_context = None
         set_usage_context = getattr(self.llm, "set_usage_context", None)
         if callable(set_usage_context):
             usage_context_token = set_usage_context(usage_context)
+            reset_usage_context = getattr(self.llm, "reset_usage_context", None)
 
         def _reset_usage_context() -> None:
-            reset_usage_context = getattr(self.llm, "reset_usage_context", None)
             if usage_context_token is not None and callable(reset_usage_context):
                 reset_usage_context(usage_context_token)
 

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -72,21 +72,25 @@ class ReflexionAgent(Agent):
         self.enable_security = enable_security
         self.approval_callback = approval_callback
 
+        provider_name = config.agent.model_provider
+        provider_cfg = config.providers.get(provider_name) if config.providers else None
+        usage_provider_name = config.agent.model_provider
+        provider_model = config.agent.model_id
+        if provider_cfg:
+            if provider_cfg.provider_name:
+                usage_provider_name = provider_cfg.provider_name
+            if provider_cfg.model_id:
+                provider_model = provider_cfg.model_id
+
         # Create LLM provider
         if llm_provider is None:
             # Resolve provider-specific overrides
-            provider_name = config.agent.model_provider
-            provider_cfg = config.providers.get(provider_name) if config.providers else None
-
             provider_api_url = config.agent.api_url
-            provider_model = config.agent.model_id
             provider_api_key = ""
 
             if provider_cfg:
                 if provider_cfg.api_url:
                     provider_api_url = provider_cfg.api_url
-                if provider_cfg.model_id:
-                    provider_model = provider_cfg.model_id
                 provider_api_key = provider_cfg.api_key or ""
 
             # Fallback to top-level api_key
@@ -103,12 +107,14 @@ class ReflexionAgent(Agent):
                 api_url=provider_api_url,
             )
 
+        self.usage_provider_name = usage_provider_name
+        self.usage_model_id = provider_model
         self.usage_recorder = UsageRecorder(self.work_dir / ".omniagent" / "usage.db")
         self.llm = cast(LLMProvider, UsageTrackingLLMProvider(
             llm_provider,
             recorder=self.usage_recorder,
-            default_provider=config.agent.model_provider,
-            default_model=config.agent.model_id,
+            default_provider=self.usage_provider_name,
+            default_model=self.usage_model_id,
         ))
 
         # Agent subsystems
@@ -442,8 +448,8 @@ class ReflexionAgent(Agent):
                 "session_id": message.session_id,
                 "user_id": message.user_id,
                 "channel_id": message.channel_id,
-                "provider": self.config.agent.model_provider,
-                "model_id": self.config.agent.model_id,
+                "provider": self.usage_provider_name,
+                "model_id": self.usage_model_id,
                 "source_component": "agent",
             },
         )
@@ -479,8 +485,8 @@ class ReflexionAgent(Agent):
         logger.info("executing_task", task=task)
 
         usage_context = {
-            "provider": self.config.agent.model_provider,
-            "model_id": self.config.agent.model_id,
+            "provider": self.usage_provider_name,
+            "model_id": self.usage_model_id,
             "source_component": "agent",
         }
         if context:

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -43,15 +43,37 @@ from .hooks import ToolHookManager, ToolCallContext
 logger = get_logger(__name__)
 
 
-def _resolve_active_model(config: OmniAgentConfig, provider_cfg: Any) -> str:
+def _agent_model_is_explicit(config: OmniAgentConfig) -> bool:
+    """Return whether agent.model_id came from user config/API rather than fallback."""
+    agent_model = str(config.agent.model_id or "").strip()
+    agent_fields_set = getattr(config.agent, "model_fields_set", set())
+    return bool(agent_model) and "model_id" in agent_fields_set
+
+
+def _mark_agent_model_implicit(config: OmniAgentConfig) -> None:
+    fields_set = getattr(config.agent, "model_fields_set", None)
+    if hasattr(fields_set, "discard"):
+        fields_set.discard("model_id")
+    pydantic_fields_set = getattr(config.agent, "__pydantic_fields_set__", None)
+    if hasattr(pydantic_fields_set, "discard"):
+        pydantic_fields_set.discard("model_id")
+
+
+def _set_effective_agent_model(config: OmniAgentConfig, model_id: str, explicit: bool) -> None:
+    """Expose the effective model without turning provider fallback into an explicit override."""
+    config.agent.model_id = model_id
+    if not explicit:
+        _mark_agent_model_implicit(config)
+
+
+def _resolve_active_model(config: OmniAgentConfig, provider_cfg: Any) -> tuple[str, bool]:
     """Resolve active model with agent.model_id overriding provider defaults."""
     provider_model = getattr(provider_cfg, "model_id", None) if provider_cfg else None
     agent_model = config.agent.model_id
-    agent_fields_set = getattr(config.agent, "model_fields_set", set())
-    if agent_model and ("model_id" in agent_fields_set or not provider_model):
-        return agent_model
-    return provider_model or agent_model
-
+    explicit = _agent_model_is_explicit(config)
+    if agent_model and (explicit or not provider_model):
+        return agent_model, explicit
+    return provider_model or agent_model, False
 
 class ReflexionAgent(Agent):
     """AI Agent with native function calling support."""
@@ -86,12 +108,12 @@ class ReflexionAgent(Agent):
         provider_cfg = config.providers.get(provider_key) if config.providers else None
         provider_api_type = provider_cfg.api_type if provider_cfg and provider_cfg.api_type else provider_key
         usage_provider_key = provider_key
-        provider_model = _resolve_active_model(config, provider_cfg)
+        provider_model, explicit_model = _resolve_active_model(config, provider_cfg)
 
         # Create LLM provider
         if llm_provider is None:
             llm_provider, usage_provider_key, provider_model, provider_api_type = self._build_llm_from_config(config)
-        config.agent.model_id = provider_model
+        _set_effective_agent_model(config, provider_model, explicit_model)
 
         self.active_api_type = provider_api_type
         self.usage_provider_key = usage_provider_key
@@ -324,8 +346,8 @@ class ReflexionAgent(Agent):
         provider_cfg = config.providers.get(provider_key) if config.providers else None
         provider_api_type = provider_cfg.api_type if provider_cfg and provider_cfg.api_type else provider_key
         usage_provider_key = provider_key
-        provider_model = _resolve_active_model(config, provider_cfg)
-        config.agent.model_id = provider_model
+        provider_model, explicit_model = _resolve_active_model(config, provider_cfg)
+        _set_effective_agent_model(config, provider_model, explicit_model)
 
         provider_api_url = config.agent.api_url or ""
         provider_api_key = ""

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -43,6 +43,16 @@ from .hooks import ToolHookManager, ToolCallContext
 logger = get_logger(__name__)
 
 
+def _resolve_active_model(config: OmniAgentConfig, provider_cfg: Any) -> str:
+    """Resolve active model with agent.model_id overriding provider defaults."""
+    provider_model = getattr(provider_cfg, "model_id", None) if provider_cfg else None
+    agent_model = config.agent.model_id
+    agent_fields_set = getattr(config.agent, "model_fields_set", set())
+    if agent_model and ("model_id" in agent_fields_set or not provider_model):
+        return agent_model
+    return provider_model or agent_model
+
+
 class ReflexionAgent(Agent):
     """AI Agent with native function calling support."""
 
@@ -72,48 +82,25 @@ class ReflexionAgent(Agent):
         self.enable_security = enable_security
         self.approval_callback = approval_callback
 
-        provider_name = config.agent.model_provider
-        provider_cfg = config.providers.get(provider_name) if config.providers else None
-        usage_provider_name = config.agent.model_provider
-        provider_model = config.agent.model_id
-        if provider_cfg:
-            if provider_cfg.provider_name:
-                usage_provider_name = provider_cfg.provider_name
-            if provider_cfg.model_id:
-                provider_model = provider_cfg.model_id
+        provider_key = config.agent.model_provider
+        provider_cfg = config.providers.get(provider_key) if config.providers else None
+        provider_api_type = provider_cfg.api_type if provider_cfg and provider_cfg.api_type else provider_key
+        usage_provider_key = provider_key
+        provider_model = _resolve_active_model(config, provider_cfg)
 
         # Create LLM provider
         if llm_provider is None:
-            # Resolve provider-specific overrides
-            provider_api_url = config.agent.api_url or ""
-            provider_api_key = ""
+            llm_provider, usage_provider_key, provider_model, provider_api_type = self._build_llm_from_config(config)
+        config.agent.model_id = provider_model
 
-            if provider_cfg:
-                if provider_cfg.api_url:
-                    provider_api_url = provider_cfg.api_url
-                provider_api_key = provider_cfg.api_key or ""
-
-            # Fallback to top-level api_key
-            if not provider_api_key:
-                provider_api_key = config.api_key or config.openai_api_key or ""
-
-            # Sync resolved model back to config so system prompt uses it
-            config.agent.model_id = provider_model
-
-            llm_provider = create_llm_provider(
-                provider=provider_name,
-                api_key=provider_api_key,
-                model=provider_model,
-                api_url=provider_api_url,
-            )
-
-        self.usage_provider_name = usage_provider_name
+        self.active_api_type = provider_api_type
+        self.usage_provider_key = usage_provider_key
         self.usage_model_id = provider_model
         self.usage_recorder = UsageRecorder(self.work_dir / ".omniagent" / "usage.db")
         self.llm = cast(LLMProvider, UsageTrackingLLMProvider(
             llm_provider,
             recorder=self.usage_recorder,
-            default_provider=self.usage_provider_name,
+            default_provider=self.usage_provider_key,
             default_model=self.usage_model_id,
         ))
 
@@ -246,13 +233,14 @@ class ReflexionAgent(Agent):
                 logger.warning("context_evolution_init_failed", error=str(e))
 
         # Initialize RL module (ONLY for local providers: vllm/sglang)
-        self._rl_active = config.agent.model_provider in ("vllm", "sglang")
+        self._rl_active = self.active_api_type in ("vllm", "sglang")
         if self._rl_active and config.rl.enabled:
             try:
                 from omniagent.rl import RLAPIServer
                 logger.info(
                     "rl_module_available",
-                    provider=config.agent.model_provider,
+                    provider=self.usage_provider_key,
+                    api_type=self.active_api_type,
                 )
             except Exception as e:
                 logger.warning("rl_init_failed", error=str(e))
@@ -330,18 +318,14 @@ class ReflexionAgent(Agent):
             native_fc=self.llm.supports_native_function_calling,
         )
 
-    def _build_llm_from_config(self, config: OmniAgentConfig) -> Tuple[LLMProvider, str, str]:
+    def _build_llm_from_config(self, config: OmniAgentConfig) -> Tuple[LLMProvider, str, str, str]:
         """Create an LLM provider from the active config and resolve provider presets."""
-        provider_name = config.agent.model_provider
-        provider_cfg = config.providers.get(provider_name) if config.providers else None
-        usage_provider_name = provider_name
-        provider_model = config.agent.model_id
-
-        if provider_cfg:
-            if provider_cfg.provider_name:
-                usage_provider_name = provider_cfg.provider_name
-            if provider_cfg.model_id:
-                provider_model = provider_cfg.model_id
+        provider_key = config.agent.model_provider
+        provider_cfg = config.providers.get(provider_key) if config.providers else None
+        provider_api_type = provider_cfg.api_type if provider_cfg and provider_cfg.api_type else provider_key
+        usage_provider_key = provider_key
+        provider_model = _resolve_active_model(config, provider_cfg)
+        config.agent.model_id = provider_model
 
         provider_api_url = config.agent.api_url or ""
         provider_api_key = ""
@@ -353,28 +337,27 @@ class ReflexionAgent(Agent):
         if not provider_api_key:
             provider_api_key = config.api_key or config.openai_api_key or ""
 
-        config.agent.model_id = provider_model
-
         llm_provider = create_llm_provider(
-            provider=provider_name,
+            provider=provider_api_type,
             api_key=provider_api_key,
             model=provider_model,
             api_url=provider_api_url,
         )
-        return llm_provider, usage_provider_name, provider_model
+        return llm_provider, usage_provider_key, provider_model, provider_api_type
 
     def apply_config(self, config: OmniAgentConfig) -> None:
         """Apply a reloaded config to the running agent without replacing the object."""
-        llm_provider, usage_provider_name, provider_model = self._build_llm_from_config(config)
+        llm_provider, usage_provider_key, provider_model, provider_api_type = self._build_llm_from_config(config)
 
         self.config = config
         self.max_iterations = config.agent.max_iterations
-        self.usage_provider_name = usage_provider_name
+        self.usage_provider_key = usage_provider_key
         self.usage_model_id = provider_model
+        self.active_api_type = provider_api_type
         self.llm = cast(LLMProvider, UsageTrackingLLMProvider(
             llm_provider,
             recorder=self.usage_recorder,
-            default_provider=self.usage_provider_name,
+            default_provider=self.usage_provider_key,
             default_model=self.usage_model_id,
         ))
 
@@ -421,7 +404,7 @@ class ReflexionAgent(Agent):
             self.register_tool(MemorySearchTool(self.memory_manager))
             self.register_tool(MemoryGetTool(self.memory_manager))
 
-        self._rl_active = config.agent.model_provider in ("vllm", "sglang")
+        self._rl_active = self.active_api_type in ("vllm", "sglang")
         if self._sentinel is not None:
             self._sentinel._main_agent_config = config.agent
         if self._guardian is not None:
@@ -438,7 +421,7 @@ class ReflexionAgent(Agent):
 
         logger.info(
             "agent_config_applied",
-            provider=self.usage_provider_name,
+            provider=self.usage_provider_key,
             model=self.usage_model_id,
             max_iterations=self.max_iterations,
         )
@@ -561,7 +544,7 @@ class ReflexionAgent(Agent):
                 "session_id": message.session_id,
                 "user_id": message.user_id,
                 "channel_id": message.channel_id,
-                "provider": self.usage_provider_name,
+                "provider": self.usage_provider_key,
                 "model_id": self.usage_model_id,
                 "source_component": "agent",
             },
@@ -598,7 +581,7 @@ class ReflexionAgent(Agent):
         logger.info("executing_task", task=task)
 
         usage_context = {
-            "provider": self.usage_provider_name,
+            "provider": self.usage_provider_key,
             "model_id": self.usage_model_id,
             "source_component": "agent",
         }

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -7,11 +7,12 @@ import re
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from omniagent.config import OmniAgentConfig
 from omniagent.gateway.router import IncomingMessage, OutgoingMessage
 from omniagent.infra import get_logger
+from .usage import UsageRecorder, UsageTrackingLLMProvider
 from omniagent.tools import (
     Tool, ToolRegistry, ReadTool, WriteTool, EditTool, BashTool,
     LoadJSONTool, SaveJSONTool, ProcessListTool, ProcessKillTool,
@@ -25,7 +26,7 @@ from omniagent.tools.http_tool import HttpTool
 from omniagent.security import ApprovalManager, ApprovalStatus, AuditLogger, ToolPolicy
 from omniagent.security.policy import ToolProfile, PolicyRule, PolicyDecision
 from .agent import Agent, AgentResult
-from .llm import LLMProvider, LLMMessage, create_llm_provider
+from .llm import LLMProvider, LLMMessage, LLMResponse, create_llm_provider
 from .context_manager import (
     ContextManager, resolve_context_window_size, detect_context_overflow,
 )
@@ -102,7 +103,13 @@ class ReflexionAgent(Agent):
                 api_url=provider_api_url,
             )
 
-        self.llm = llm_provider
+        self.usage_recorder = UsageRecorder(self.work_dir / ".omniagent" / "usage.db")
+        self.llm = cast(LLMProvider, UsageTrackingLLMProvider(
+            llm_provider,
+            recorder=self.usage_recorder,
+            default_provider=config.agent.model_provider,
+            default_model=config.agent.model_id,
+        ))
 
         # Agent subsystems
         self.event_bus = EventBus()
@@ -429,7 +436,17 @@ class ReflexionAgent(Agent):
                 logger.warning("memory_sync_failed", error=str(e))
 
         # Execute task
-        result = await self.execute(message.content)
+        result = await self.execute(
+            message.content,
+            context={
+                "session_id": message.session_id,
+                "user_id": message.user_id,
+                "channel_id": message.channel_id,
+                "provider": self.config.agent.model_provider,
+                "model_id": self.config.agent.model_id,
+                "source_component": "agent",
+            },
+        )
 
         # Create response
         return OutgoingMessage(
@@ -461,187 +478,208 @@ class ReflexionAgent(Agent):
         """
         logger.info("executing_task", task=task)
 
-        # Reset per-execution state
-        self._guardian_blocked_events = []
-        self._parallel_exec_count = 0
-        self._parallel_tools_count = 0
-        self._compaction_count = 0
-        self._stuck_detected_count = 0
-        self._sentinel_activated = False
-        self._tool_name_history = []
-        self._result_hashes = []
+        usage_context = {
+            "provider": self.config.agent.model_provider,
+            "model_id": self.config.agent.model_id,
+            "source_component": "agent",
+        }
+        if context:
+            usage_context.update(context)
+        usage_context_token = None
+        set_usage_context = getattr(self.llm, "set_usage_context", None)
+        if callable(set_usage_context):
+            usage_context_token = set_usage_context(usage_context)
 
-        # ── Feedback Detection ──────────────────────────────────────
-        # If the user's message looks like feedback on a prior execution
-        # (corrections, preferences, "don't do X, do Y"), route it through
-        # the lesson extraction pipeline before executing as a new task.
-        self._pending_user_feedback: Optional[List[str]] = None
-        if self._context_evolution and self.conversation_history:
-            feedback_result = await self._detect_user_feedback(task)
-            if feedback_result:
-                self._pending_user_feedback = [feedback_result]
-                logger.info(
-                    "user_feedback_detected",
-                    feedback=feedback_result[:100],
-                )
+        def _reset_usage_context() -> None:
+            reset_usage_context = getattr(self.llm, "reset_usage_context", None)
+            if usage_context_token is not None and callable(reset_usage_context):
+                reset_usage_context(usage_context_token)
 
-        # Sentinel: check if task is complex enough to activate planning
-        # Pass skills_summary so Sentinel can make skill-aware decisions
-        sentinel_plan = None
-        skills_summary = self.skill_manager.format_skills_summary()
-        if self._sentinel:
-            # Try to recover existing plan first
-            sentinel_plan = self._sentinel.load_plan(task)
-            if not sentinel_plan:
-                should_activate, reason = await self._sentinel.should_activate_with_llm(
-                    task, self.llm,
-                    skills_summary=skills_summary,
-                )
-                if should_activate:
-                    self._sentinel_activated = True
-                    logger.info("sentinel_activating", reason=reason)
-                    try:
-                        sentinel_plan = await self._sentinel.decompose(
-                            task, self.llm,
-                            skills_summary=skills_summary,
-                        )
-                        # Inject plan context into conversation
-                        plan_text = self._sentinel.get_progress_summary()
-                        if plan_text:
-                            self._steering_queue.append(
-                                f"[Sentinel Plan] Complex task detected. "
-                                f"Working through the following milestone plan:\n{plan_text}\n"
-                                f"Execute the milestones in order. Mark each as complete before moving on."
-                            )
-                    except Exception as e:
-                        logger.warning("sentinel_decompose_failed", error=str(e))
-            else:
-                # Recovered plan — inject progress context
-                plan_text = self._sentinel.get_progress_summary()
-                if plan_text:
-                    self._steering_queue.append(
-                        f"[Sentinel Plan Recovery] Resuming previous task plan:\n{plan_text}\n"
-                        f"Continue from where you left off."
-                    )
-        self._sentinel_plan = sentinel_plan
-
-        # First attempt
-        result = await self._execute_single_attempt(task)
-
-        if result.success or not self.config.agent.reflexion_enabled:
-            # Sentinel: mark milestone completed on success
-            if self._sentinel and self._sentinel.is_active:
-                try:
-                    ms = self._sentinel.get_current_milestone()
-                    if ms:
-                        await self._sentinel.mark_milestone_completed(
-                            ms, result_summary=result.response[:200]
-                        )
-                except Exception as e:
-                    logger.warning("sentinel_milestone_complete_failed", error=str(e))
-            return result
-
-        # Reflexion retry loop
-        max_retries = self.config.agent.reflexion_max_attempts
-        for retry in range(max_retries):
-            # Sentinel: activate planning on repeated reflexion failures
-            if self._sentinel and not self._sentinel_activated:
-                should, reason = self._sentinel.should_activate(
-                    task, reflexion_failure_count=retry + 1
-                )
-                if should:
-                    self._sentinel_activated = True
-                    logger.info("sentinel_activating_on_reflexion", reason=reason, attempt=retry + 1)
-                    try:
-                        self._sentinel_plan = await self._sentinel.decompose(task, self.llm)
-                        plan_text = self._sentinel.get_progress_summary()
-                        if plan_text:
-                            self._steering_queue.append(
-                                f"[Sentinel Plan] Activated due to repeated failures. "
-                                f"Working through the following milestone plan:\n{plan_text}\n"
-                                f"Execute the milestones in order. Mark each as complete before moving on."
-                            )
-                    except Exception as e:
-                        logger.warning("sentinel_decompose_on_reflexion_failed", error=str(e))
-
-            logger.info(
-                "reflexion_retry",
-                attempt=retry + 1,
-                max_retries=max_retries,
-                error=result.error or "max_iterations",
-            )
-
-            # Generate reflection on what went wrong
-            reflection = await self._reflect(task, result)
-            if reflection:
-                self._reflections.append(reflection)
-                logger.info("reflection_generated", length=len(reflection))
-
-            # Extract key discoveries before clearing conversation
-            self._discoveries = self._extract_discoveries()
-            if self._discoveries:
-                logger.info("discoveries_extracted", files=self._discoveries.count("\n") + 1)
-
-            # Reset conversation for fresh attempt, keeping reflections and discoveries
-            self.conversation_history = []
-            self._recent_tool_calls = []
-            self._recent_errors = []
+        try:
+            # Reset per-execution state
+            self._guardian_blocked_events = []
+            self._parallel_exec_count = 0
+            self._parallel_tools_count = 0
+            self._compaction_count = 0
+            self._stuck_detected_count = 0
+            self._sentinel_activated = False
             self._tool_name_history = []
             self._result_hashes = []
-            # Keep _context_hints, _reflections, and _discoveries across retries
 
-            # Retry with reflection injected into system prompt
+            # ── Feedback Detection ──────────────────────────────────────
+            # If the user's message looks like feedback on a prior execution
+            # (corrections, preferences, "don't do X, do Y"), route it through
+            # the lesson extraction pipeline before executing as a new task.
+            self._pending_user_feedback: Optional[List[str]] = None
+            if self._context_evolution and self.conversation_history:
+                feedback_result = await self._detect_user_feedback(task)
+                if feedback_result:
+                    self._pending_user_feedback = [feedback_result]
+                    logger.info(
+                        "user_feedback_detected",
+                        feedback=feedback_result[:100],
+                    )
+
+            # Sentinel: check if task is complex enough to activate planning
+            # Pass skills_summary so Sentinel can make skill-aware decisions
+            sentinel_plan = None
+            skills_summary = self.skill_manager.format_skills_summary()
+            if self._sentinel:
+                # Try to recover existing plan first
+                sentinel_plan = self._sentinel.load_plan(task)
+                if not sentinel_plan:
+                    should_activate, reason = await self._sentinel.should_activate_with_llm(
+                        task, self.llm,
+                        skills_summary=skills_summary,
+                    )
+                    if should_activate:
+                        self._sentinel_activated = True
+                        logger.info("sentinel_activating", reason=reason)
+                        try:
+                            sentinel_plan = await self._sentinel.decompose(
+                                task, self.llm,
+                                skills_summary=skills_summary,
+                            )
+                            # Inject plan context into conversation
+                            plan_text = self._sentinel.get_progress_summary()
+                            if plan_text:
+                                self._steering_queue.append(
+                                    f"[Sentinel Plan] Complex task detected. "
+                                    f"Working through the following milestone plan:\n{plan_text}\n"
+                                    f"Execute the milestones in order. Mark each as complete before moving on."
+                                )
+                        except Exception as e:
+                            logger.warning("sentinel_decompose_failed", error=str(e))
+                else:
+                    # Recovered plan — inject progress context
+                    plan_text = self._sentinel.get_progress_summary()
+                    if plan_text:
+                        self._steering_queue.append(
+                            f"[Sentinel Plan Recovery] Resuming previous task plan:\n{plan_text}\n"
+                            f"Continue from where you left off."
+                        )
+            self._sentinel_plan = sentinel_plan
+
+            # First attempt
             result = await self._execute_single_attempt(task)
-            if result.success:
-                logger.info("reflexion_succeeded", attempt=retry + 1)
-                break
 
-        result.metadata["reflections_count"] = len(self._reflections)
+            if result.success or not self.config.agent.reflexion_enabled:
+                # Sentinel: mark milestone completed on success
+                if self._sentinel and self._sentinel.is_active:
+                    try:
+                        ms = self._sentinel.get_current_milestone()
+                        if ms:
+                            await self._sentinel.mark_milestone_completed(
+                                ms, result_summary=result.response[:200]
+                            )
+                    except Exception as e:
+                        logger.warning("sentinel_milestone_complete_failed", error=str(e))
+                return result
 
-        # ── Collect execution highlights ──
-        now = datetime.now().strftime("%Y-%m-%d %H:%M")
-        highlights = []
+            # Reflexion retry loop
+            max_retries = self.config.agent.reflexion_max_attempts
+            for retry in range(max_retries):
+                # Sentinel: activate planning on repeated reflexion failures
+                if self._sentinel and not self._sentinel_activated:
+                    should, reason = self._sentinel.should_activate(
+                        task, reflexion_failure_count=retry + 1
+                    )
+                    if should:
+                        self._sentinel_activated = True
+                        logger.info("sentinel_activating_on_reflexion", reason=reason, attempt=retry + 1)
+                        try:
+                            self._sentinel_plan = await self._sentinel.decompose(task, self.llm)
+                            plan_text = self._sentinel.get_progress_summary()
+                            if plan_text:
+                                self._steering_queue.append(
+                                    f"[Sentinel Plan] Activated due to repeated failures. "
+                                    f"Working through the following milestone plan:\n{plan_text}\n"
+                                    f"Execute the milestones in order. Mark each as complete before moving on."
+                                )
+                        except Exception as e:
+                            logger.warning("sentinel_decompose_on_reflexion_failed", error=str(e))
 
-        # Reflections
-        if self._reflections:
-            highlights.append({"type": "reflections", "count": len(self._reflections), "time": now})
+                logger.info(
+                    "reflexion_retry",
+                    attempt=retry + 1,
+                    max_retries=max_retries,
+                    error=result.error or "max_iterations",
+                )
 
-        # Guardian session summary
-        if self._guardian:
-            summary = self._guardian.get_session_summary()
-            if summary:
-                highlights.append({"type": "guardian", "summary": summary, "time": now})
+                # Generate reflection on what went wrong
+                reflection = await self._reflect(task, result)
+                if reflection:
+                    self._reflections.append(reflection)
+                    logger.info("reflection_generated", length=len(reflection))
 
-        # Tool stats
-        tools_used = list(dict.fromkeys(self._tool_name_history))
-        if tools_used:
-            highlights.append({"type": "tools", "used": tools_used, "total_calls": self.agent_state.total_tool_calls, "time": now})
+                # Extract key discoveries before clearing conversation
+                self._discoveries = self._extract_discoveries()
+                if self._discoveries:
+                    logger.info("discoveries_extracted", files=self._discoveries.count("\n") + 1)
 
-        # Skill evolution highlights (time from AGENT_END handler)
-        if self._skill_evolution and self._skill_evolution.last_session_results:
-            sr = self._skill_evolution.last_session_results
-            ev_time = sr.get("time", now)
-            if sr.get("skill_compiled"):
-                highlights.append({"type": "skill_compiled", "time": ev_time})
-            if sr.get("patches_written"):
-                highlights.append({"type": "skill_evolution", "time": ev_time})
+                # Reset conversation for fresh attempt, keeping reflections and discoveries
+                self.conversation_history = []
+                self._recent_tool_calls = []
+                self._recent_errors = []
+                self._tool_name_history = []
+                self._result_hashes = []
+                # Keep _context_hints, _reflections, and _discoveries across retries
 
-        # Context evolution highlights (time from AGENT_END handler)
-        if self._context_evolution and self._context_evolution.last_session_results:
-            cr = self._context_evolution.last_session_results
-            ev_time = cr.get("time", now)
-            if cr.get("rules_promoted"):
-                highlights.append({"type": "rules_promoted", "count": cr["rules_promoted"], "time": ev_time})
-            if cr.get("lessons_extracted"):
-                highlights.append({"type": "lessons_extracted", "count": cr["lessons_extracted"], "time": ev_time})
+                # Retry with reflection injected into system prompt
+                result = await self._execute_single_attempt(task)
+                if result.success:
+                    logger.info("reflexion_succeeded", attempt=retry + 1)
+                    break
 
-        result.metadata["execution_highlights"] = highlights
+            result.metadata["reflections_count"] = len(self._reflections)
 
-        # Invalidate skill cache so trial skills become visible
-        if self._skill_evolution and self.skill_manager:
-            self.skill_manager.invalidate_cache()
+            # ── Collect execution highlights ──
+            now = datetime.now().strftime("%Y-%m-%d %H:%M")
+            highlights = []
 
-        return result
+            # Reflections
+            if self._reflections:
+                highlights.append({"type": "reflections", "count": len(self._reflections), "time": now})
+
+            # Guardian session summary
+            if self._guardian:
+                summary = self._guardian.get_session_summary()
+                if summary:
+                    highlights.append({"type": "guardian", "summary": summary, "time": now})
+
+            # Tool stats
+            tools_used = list(dict.fromkeys(self._tool_name_history))
+            if tools_used:
+                highlights.append({"type": "tools", "used": tools_used, "total_calls": self.agent_state.total_tool_calls, "time": now})
+
+            # Skill evolution highlights (time from AGENT_END handler)
+            if self._skill_evolution and self._skill_evolution.last_session_results:
+                sr = self._skill_evolution.last_session_results
+                ev_time = sr.get("time", now)
+                if sr.get("skill_compiled"):
+                    highlights.append({"type": "skill_compiled", "time": ev_time})
+                if sr.get("patches_written"):
+                    highlights.append({"type": "skill_evolution", "time": ev_time})
+
+            # Context evolution highlights (time from AGENT_END handler)
+            if self._context_evolution and self._context_evolution.last_session_results:
+                cr = self._context_evolution.last_session_results
+                ev_time = cr.get("time", now)
+                if cr.get("rules_promoted"):
+                    highlights.append({"type": "rules_promoted", "count": cr["rules_promoted"], "time": ev_time})
+                if cr.get("lessons_extracted"):
+                    highlights.append({"type": "lessons_extracted", "count": cr["lessons_extracted"], "time": ev_time})
+
+            result.metadata["execution_highlights"] = highlights
+
+            # Invalidate skill cache so trial skills become visible
+            if self._skill_evolution and self.skill_manager:
+                self.skill_manager.invalidate_cache()
+
+            return result
+
+        finally:
+            _reset_usage_context()
 
     async def _execute_single_attempt(
         self,

--- a/omniagent/agents/skill_evolution.py
+++ b/omniagent/agents/skill_evolution.py
@@ -1209,6 +1209,7 @@ class SkillEvolutionManager:
             skill_compiled = False
             patch_written = False
             compiled = None
+            patch = None
 
             # Try skill compilation
             if pattern_recorded:

--- a/omniagent/agents/usage.py
+++ b/omniagent/agents/usage.py
@@ -635,7 +635,7 @@ class UsageTrackingLLMProvider:
             stream=stream,
             tools=tools,
         )
-        response.metadata.setdefault("provider", self.default_provider)
+        response.metadata["provider"] = self.default_provider
         response.metadata.setdefault("model", self.default_model)
         self.recorder.record_response(
             response,

--- a/omniagent/agents/usage.py
+++ b/omniagent/agents/usage.py
@@ -51,10 +51,9 @@ def _normalize_pricing_entry(
         "input": _as_float(cost.get("input")),
         "output": _as_float(cost.get("output")),
         "cache_read": _as_float(cost.get("cache_read")),
-        "cache_write": _as_float(cost.get("cache_write")),
         "source": source,
     }
-    if all(pricing[key] is None for key in ("input", "output", "cache_read", "cache_write")):
+    if all(pricing[key] is None for key in ("input", "output", "cache_read")):
         return None
     return pricing
 
@@ -106,6 +105,9 @@ def load_models_dev_pricing_catalog(
         cache_ttl_seconds=cache_ttl_seconds,
     )
     catalog: Dict[str, Dict[str, Any]] = {}
+    model_catalog: Dict[str, Dict[str, Any]] = {}
+    ambiguous_model_ids = set()
+    price_keys = ("input", "output", "cache_read")
     for provider_id, provider_data in payload.items():
         if not isinstance(provider_data, dict):
             continue
@@ -120,7 +122,20 @@ def load_models_dev_pricing_catalog(
                 continue
             pricing = _normalize_pricing_entry(cost, "models.dev")
             if pricing:
-                catalog[_pricing_key(str(provider_id), str(model_id))] = pricing
+                model_key = str(model_id)
+                catalog[_pricing_key(str(provider_id), model_key)] = pricing
+                existing = model_catalog.get(model_key)
+                if existing is None:
+                    model_catalog[model_key] = pricing
+                elif any(existing.get(key) != pricing.get(key) for key in price_keys):
+                    ambiguous_model_ids.add(model_key)
+
+    # Bare model_id fallback is intentionally conservative: if multiple
+    # providers publish different prices for the same model_id, do not guess.
+    # Users can still add an explicit provider/model override in config.
+    for model_id, pricing in model_catalog.items():
+        if model_id not in ambiguous_model_ids:
+            catalog.setdefault(model_id, pricing)
     return catalog
 
 
@@ -152,7 +167,7 @@ def _lookup_pricing(
                 normalized = _normalize_pricing_entry(override, "config")
                 if normalized:
                     merged = dict(merged or {})
-                    for price_key in ("input", "output", "cache_read", "cache_write"):
+                    for price_key in ("input", "output", "cache_read"):
                         if normalized.get(price_key) is not None:
                             merged[price_key] = normalized[price_key]
                     merged["source"] = "config"
@@ -193,21 +208,17 @@ def enrich_usage_summary_with_pricing(
             cache_read_rate = pricing.get("cache_read")
             if cache_read_rate is None:
                 cache_read_rate = input_rate
-            cache_write_rate = pricing.get("cache_write")
-            if cache_write_rate is None:
-                cache_write_rate = input_rate
 
-            input_cost = _cost_component(_as_int(row.get("input_tokens_uncached")), input_rate)
+            input_billable_tokens = _as_int(row.get("input_tokens_uncached")) + _as_int(
+                row.get("cache_creation_input_tokens")
+            )
+            input_cost = _cost_component(input_billable_tokens, input_rate)
             cache_read_cost = _cost_component(
                 _as_int(row.get("cache_read_input_tokens")) or _as_int(row.get("cached_input_tokens")),
                 cache_read_rate,
             )
-            cache_write_cost = _cost_component(
-                _as_int(row.get("cache_creation_input_tokens")),
-                cache_write_rate,
-            )
             output_cost = _cost_component(_as_int(row.get("output_tokens")), output_rate)
-            row_cost = input_cost + cache_read_cost + cache_write_cost + output_cost
+            row_cost = input_cost + cache_read_cost + output_cost
             total_cost += row_cost
             priced_models += 1
             row["pricing"] = {
@@ -215,7 +226,6 @@ def enrich_usage_summary_with_pricing(
                 "input_per_million_usd": input_rate,
                 "output_per_million_usd": output_rate,
                 "cache_read_per_million_usd": cache_read_rate,
-                "cache_write_per_million_usd": cache_write_rate,
             }
             row["estimated_cost_usd"] = round(row_cost, 8)
         else:

--- a/omniagent/agents/usage.py
+++ b/omniagent/agents/usage.py
@@ -1,0 +1,659 @@
+"""Best-effort LLM usage accounting.
+
+The usage ledger is intentionally observational: failed or delayed accounting must
+never fail an LLM response. Writes go through a bounded queue and a single
+background SQLite writer so request concurrency is not limited by DB locks.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import threading
+import time
+import urllib.request
+import uuid
+from contextvars import ContextVar, Token
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from omniagent.infra import get_logger
+
+logger = get_logger(__name__)
+
+
+_MODELS_DEV_CACHE_LOCK = threading.Lock()
+_MODELS_DEV_CACHE: Dict[str, Dict[str, Any]] = {}
+_PROVIDER_ALIASES = {"gemini": "google"}
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _pricing_key(provider: str, model_id: str) -> str:
+    return f"{provider}/{model_id}"
+
+
+def _normalize_pricing_entry(
+    cost: Dict[str, Any],
+    source: str,
+) -> Optional[Dict[str, Any]]:
+    pricing = {
+        "input": _as_float(cost.get("input")),
+        "output": _as_float(cost.get("output")),
+        "cache_read": _as_float(cost.get("cache_read")),
+        "cache_write": _as_float(cost.get("cache_write")),
+        "source": source,
+    }
+    if all(pricing[key] is None for key in ("input", "output", "cache_read", "cache_write")):
+        return None
+    return pricing
+
+
+def load_models_dev_catalog(
+    source_url: str,
+    timeout_seconds: float = 2.0,
+    cache_ttl_seconds: int = 900,
+) -> Dict[str, Any]:
+    """Fetch and cache the raw models.dev catalog."""
+    if not source_url:
+        return {}
+
+    now = time.time()
+    with _MODELS_DEV_CACHE_LOCK:
+        cached = _MODELS_DEV_CACHE.get(source_url)
+        if cached and cache_ttl_seconds > 0:
+            if now - cached["fetched_at"] < cache_ttl_seconds:
+                return cached["catalog"]
+
+    try:
+        request = urllib.request.Request(
+            source_url,
+            headers={"User-Agent": "OmniAgent/usage-pricing"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.load(response)
+    except Exception as exc:
+        logger.debug("models_dev_catalog_fetch_failed", url=source_url, error=str(exc))
+        with _MODELS_DEV_CACHE_LOCK:
+            cached = _MODELS_DEV_CACHE.get(source_url)
+            return cached["catalog"] if cached else {}
+
+    catalog = payload if isinstance(payload, dict) else {}
+    with _MODELS_DEV_CACHE_LOCK:
+        _MODELS_DEV_CACHE[source_url] = {"fetched_at": now, "catalog": catalog}
+    return catalog
+
+
+def load_models_dev_pricing_catalog(
+    source_url: str,
+    timeout_seconds: float = 2.0,
+    cache_ttl_seconds: int = 900,
+) -> Dict[str, Dict[str, Any]]:
+    """Extract models.dev pricing data as USD per million tokens."""
+    payload = load_models_dev_catalog(
+        source_url=source_url,
+        timeout_seconds=timeout_seconds,
+        cache_ttl_seconds=cache_ttl_seconds,
+    )
+    catalog: Dict[str, Dict[str, Any]] = {}
+    for provider_id, provider_data in payload.items():
+        if not isinstance(provider_data, dict):
+            continue
+        models = provider_data.get("models")
+        if not isinstance(models, dict):
+            continue
+        for model_id, model_data in models.items():
+            if not isinstance(model_data, dict):
+                continue
+            cost = model_data.get("cost")
+            if not isinstance(cost, dict):
+                continue
+            pricing = _normalize_pricing_entry(cost, "models.dev")
+            if pricing:
+                catalog[_pricing_key(str(provider_id), str(model_id))] = pricing
+    return catalog
+
+
+def _lookup_pricing(
+    provider: str,
+    model_id: str,
+    catalog: Dict[str, Dict[str, Any]],
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Optional[Dict[str, Any]]:
+    provider = str(provider or "unknown")
+    model_id = str(model_id or "unknown")
+    aliased_provider = _PROVIDER_ALIASES.get(provider, provider)
+    candidates = [
+        _pricing_key(provider, model_id),
+        _pricing_key(aliased_provider, model_id),
+        model_id,
+    ]
+
+    merged: Optional[Dict[str, Any]] = None
+    for key in candidates:
+        if key in catalog:
+            merged = dict(catalog[key])
+            break
+
+    if overrides:
+        for key in candidates:
+            override = overrides.get(key)
+            if isinstance(override, dict):
+                normalized = _normalize_pricing_entry(override, "config")
+                if normalized:
+                    merged = dict(merged or {})
+                    for price_key in ("input", "output", "cache_read", "cache_write"):
+                        if normalized.get(price_key) is not None:
+                            merged[price_key] = normalized[price_key]
+                    merged["source"] = "config"
+                break
+
+    return merged
+
+
+def _cost_component(tokens: int, rate_per_million: Optional[float]) -> float:
+    if rate_per_million is None or tokens <= 0:
+        return 0.0
+    return tokens * rate_per_million / 1_000_000
+
+
+def enrich_usage_summary_with_pricing(
+    summary: Dict[str, Any],
+    catalog: Dict[str, Dict[str, Any]],
+    overrides: Optional[Dict[str, Dict[str, float]]] = None,
+) -> Dict[str, Any]:
+    """Add best-effort USD cost estimates to usage summary rows."""
+    result = dict(summary)
+    totals = dict(result.get("totals") or {})
+    by_model = []
+    total_cost = 0.0
+    priced_models = 0
+
+    for row_data in result.get("by_model", []):
+        row = dict(row_data)
+        pricing = _lookup_pricing(
+            str(row.get("provider", "unknown")),
+            str(row.get("model_id", "unknown")),
+            catalog,
+            overrides,
+        )
+        if pricing:
+            input_rate = pricing.get("input")
+            output_rate = pricing.get("output")
+            cache_read_rate = pricing.get("cache_read")
+            if cache_read_rate is None:
+                cache_read_rate = input_rate
+            cache_write_rate = pricing.get("cache_write")
+            if cache_write_rate is None:
+                cache_write_rate = input_rate
+
+            input_cost = _cost_component(_as_int(row.get("input_tokens_uncached")), input_rate)
+            cache_read_cost = _cost_component(
+                _as_int(row.get("cache_read_input_tokens")) or _as_int(row.get("cached_input_tokens")),
+                cache_read_rate,
+            )
+            cache_write_cost = _cost_component(
+                _as_int(row.get("cache_creation_input_tokens")),
+                cache_write_rate,
+            )
+            output_cost = _cost_component(_as_int(row.get("output_tokens")), output_rate)
+            row_cost = input_cost + cache_read_cost + cache_write_cost + output_cost
+            total_cost += row_cost
+            priced_models += 1
+            row["pricing"] = {
+                "source": pricing.get("source"),
+                "input_per_million_usd": input_rate,
+                "output_per_million_usd": output_rate,
+                "cache_read_per_million_usd": cache_read_rate,
+                "cache_write_per_million_usd": cache_write_rate,
+            }
+            row["estimated_cost_usd"] = round(row_cost, 8)
+        else:
+            row["pricing"] = None
+            row["estimated_cost_usd"] = None
+        by_model.append(row)
+
+    totals["estimated_cost_usd"] = round(total_cost, 8)
+    totals["estimated_cost_scope"] = "returned_models"
+    totals["priced_models"] = priced_models
+    totals["unpriced_models"] = len(by_model) - priced_models
+    result["totals"] = totals
+    result["by_model"] = by_model
+    result["pricing"] = {
+        "catalog_models": len(catalog),
+        "overrides": len(overrides or {}),
+        "unit": "USD per million tokens",
+    }
+    return result
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS usage_events (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    created_at_unix REAL NOT NULL,
+    session_id TEXT,
+    user_id TEXT,
+    channel_id TEXT,
+    source_component TEXT,
+    provider TEXT NOT NULL,
+    model_id TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    input_tokens_uncached INTEGER NOT NULL DEFAULT 0,
+    cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_input_tokens INTEGER NOT NULL DEFAULT 0,
+    cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    total_tokens INTEGER NOT NULL DEFAULT 0,
+    raw_usage_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_model_time
+ON usage_events(provider, model_id, created_at_unix);
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_session
+ON usage_events(session_id);
+"""
+
+
+def _as_int(value: Any) -> int:
+    """Convert provider usage values to non-negative integers."""
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def _nested_int(data: Dict[str, Any], parent: str, child: str) -> int:
+    nested = data.get(parent)
+    if isinstance(nested, dict):
+        return _as_int(nested.get(child))
+    return 0
+
+
+def _local_today_start_unix() -> float:
+    now = datetime.now().astimezone()
+    return now.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
+
+
+def normalize_usage(
+    usage: Optional[Dict[str, Any]],
+    metadata: Optional[Dict[str, Any]] = None,
+    context: Optional[Dict[str, Any]] = None,
+    default_provider: str = "unknown",
+    default_model: str = "unknown",
+) -> Dict[str, Any]:
+    """Normalize provider usage shapes into ledger columns."""
+    raw_usage = usage or {}
+    response_meta = metadata or {}
+    call_context = context or {}
+
+    input_tokens = _as_int(
+        raw_usage.get("input_tokens", raw_usage.get("prompt_tokens"))
+    )
+    output_tokens = _as_int(
+        raw_usage.get("output_tokens", raw_usage.get("completion_tokens"))
+    )
+
+    nested_cached = _nested_int(raw_usage, "prompt_tokens_details", "cached_tokens")
+    cached_input_tokens = _as_int(
+        raw_usage.get(
+            "cached_input_tokens",
+            raw_usage.get("cached_tokens", nested_cached),
+        )
+    )
+    cache_read_input_tokens = _as_int(
+        raw_usage.get("cache_read_input_tokens", cached_input_tokens)
+    )
+    cache_creation_input_tokens = _as_int(raw_usage.get("cache_creation_input_tokens"))
+
+    explicit_uncached = raw_usage.get("input_tokens_uncached")
+    if explicit_uncached is None:
+        input_tokens_uncached = max(input_tokens - cached_input_tokens, 0)
+    else:
+        input_tokens_uncached = _as_int(explicit_uncached)
+
+    total_tokens = _as_int(raw_usage.get("total_tokens"))
+    if total_tokens == 0:
+        total_tokens = (
+            input_tokens
+            + cache_creation_input_tokens
+            + cache_read_input_tokens
+            + output_tokens
+        )
+
+    default_provider_value = default_provider if default_provider != "unknown" else None
+    provider = str(
+        call_context.get("provider")
+        or default_provider_value
+        or response_meta.get("provider")
+        or "unknown"
+    )
+    model_id = str(
+        call_context.get("model_id")
+        or response_meta.get("model")
+        or default_model
+        or "unknown"
+    )
+
+    return {
+        "session_id": call_context.get("session_id"),
+        "user_id": call_context.get("user_id"),
+        "channel_id": call_context.get("channel_id"),
+        "source_component": call_context.get("source_component", "llm"),
+        "provider": provider,
+        "model_id": model_id,
+        "input_tokens": input_tokens,
+        "input_tokens_uncached": input_tokens_uncached,
+        "cache_creation_input_tokens": cache_creation_input_tokens,
+        "cache_read_input_tokens": cache_read_input_tokens,
+        "cached_input_tokens": cached_input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "raw_usage_json": json.dumps(raw_usage, ensure_ascii=False, sort_keys=True),
+    }
+
+
+class UsageRecorder:
+    """SQLite-backed usage ledger with best-effort non-blocking writes."""
+
+    def __init__(self, db_path: Path, max_queue_size: int = 10000):
+        self.db_path = db_path
+        self.max_queue_size = max_queue_size
+        self.dropped_events = 0
+        self.failed_events = 0
+        self._enabled = True
+        self._queue: queue.Queue[Optional[Dict[str, Any]]] = queue.Queue(
+            maxsize=max_queue_size
+        )
+        self._stop_event = threading.Event()
+        self._writer = threading.Thread(
+            target=self._writer_loop,
+            name="omniagent-usage-writer",
+            daemon=True,
+        )
+
+        try:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._ensure_schema(self.db_path)
+            self._writer.start()
+        except Exception as exc:
+            self._enabled = False
+            logger.warning("usage_recorder_disabled", error=str(exc))
+
+    @staticmethod
+    def _configure_connection(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=1000")
+
+    @classmethod
+    def _ensure_schema(cls, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path), timeout=1.0)
+        try:
+            cls._configure_connection(conn)
+            conn.executescript(_SCHEMA_SQL)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def record(self, event: Dict[str, Any]) -> None:
+        """Queue a usage event without blocking the caller."""
+        if not self._enabled:
+            return
+        try:
+            self._queue.put_nowait(event)
+        except queue.Full:
+            self.dropped_events += 1
+            logger.debug("usage_event_dropped", reason="queue_full")
+
+    def record_response(
+        self,
+        response: Any,
+        context: Optional[Dict[str, Any]] = None,
+        default_provider: str = "unknown",
+        default_model: str = "unknown",
+    ) -> None:
+        """Normalize and queue an LLM response usage event."""
+        try:
+            event = normalize_usage(
+                response.usage,
+                metadata=response.metadata,
+                context=context,
+                default_provider=default_provider,
+                default_model=default_model,
+            )
+            if (
+                event["total_tokens"] == 0
+                and event["input_tokens"] == 0
+                and event["output_tokens"] == 0
+            ):
+                return
+            self.record(event)
+        except Exception as exc:
+            self.failed_events += 1
+            logger.debug("usage_event_normalize_failed", error=str(exc))
+
+    def _writer_loop(self) -> None:
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = sqlite3.connect(str(self.db_path), timeout=1.0)
+            self._configure_connection(conn)
+            while not self._stop_event.is_set():
+                try:
+                    event = self._queue.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+
+                if event is None:
+                    self._queue.task_done()
+                    break
+
+                try:
+                    self._insert_event(conn, event)
+                    conn.commit()
+                except Exception as exc:
+                    self.failed_events += 1
+                    logger.debug("usage_event_write_failed", error=str(exc))
+                finally:
+                    self._queue.task_done()
+        except Exception as exc:
+            self._enabled = False
+            logger.warning("usage_writer_stopped", error=str(exc))
+        finally:
+            if conn is not None:
+                conn.close()
+
+    @staticmethod
+    def _insert_event(conn: sqlite3.Connection, event: Dict[str, Any]) -> None:
+        now = time.time()
+        created_at = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+        conn.execute(
+            """INSERT INTO usage_events (
+                id, created_at, created_at_unix, session_id, user_id, channel_id,
+                source_component, provider, model_id, input_tokens,
+                input_tokens_uncached, cache_creation_input_tokens,
+                cache_read_input_tokens, cached_input_tokens, output_tokens,
+                total_tokens, raw_usage_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                str(uuid.uuid4()),
+                created_at,
+                now,
+                event.get("session_id"),
+                event.get("user_id"),
+                event.get("channel_id"),
+                event.get("source_component"),
+                event.get("provider", "unknown"),
+                event.get("model_id", "unknown"),
+                event.get("input_tokens", 0),
+                event.get("input_tokens_uncached", 0),
+                event.get("cache_creation_input_tokens", 0),
+                event.get("cache_read_input_tokens", 0),
+                event.get("cached_input_tokens", 0),
+                event.get("output_tokens", 0),
+                event.get("total_tokens", 0),
+                event.get("raw_usage_json"),
+            ),
+        )
+
+    def summary(self, days: Optional[int] = None, limit: int = 50) -> Dict[str, Any]:
+        """Return aggregate usage grouped by provider/model.
+
+        When days is omitted, the summary defaults to the local calendar day
+        starting at 00:00. Explicit days values keep their rolling-window
+        meaning and are validated by API callers.
+        """
+        self._ensure_schema(self.db_path)
+        safe_limit = max(1, min(limit, 500))
+        where = "WHERE created_at_unix >= ?"
+        if days is None:
+            window_label = "today"
+            params: List[Any] = [_local_today_start_unix()]
+        else:
+            window_label = f"last_{days}_days"
+            params = [time.time() - days * 86400]
+
+        conn = sqlite3.connect(str(self.db_path), timeout=1.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            self._configure_connection(conn)
+            totals = conn.execute(
+                f"""SELECT
+                    COUNT(*) AS events,
+                    COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                    COALESCE(SUM(input_tokens_uncached), 0) AS input_tokens_uncached,
+                    COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+                    COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
+                    COALESCE(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                    COALESCE(SUM(total_tokens), 0) AS total_tokens
+                FROM usage_events {where}""",
+                params,
+            ).fetchone()
+            by_model = conn.execute(
+                f"""SELECT
+                    provider,
+                    model_id,
+                    COUNT(*) AS events,
+                    COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                    COALESCE(SUM(input_tokens_uncached), 0) AS input_tokens_uncached,
+                    COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+                    COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
+                    COALESCE(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                    COALESCE(SUM(total_tokens), 0) AS total_tokens
+                FROM usage_events {where}
+                GROUP BY provider, model_id
+                ORDER BY total_tokens DESC
+                LIMIT ?""",
+                [*params, safe_limit],
+            ).fetchall()
+
+            return {
+                "window": window_label,
+                "window_days": days,
+                "queue_size": self._queue.qsize() if self._enabled else 0,
+                "queue_capacity": self.max_queue_size,
+                "dropped_events": self.dropped_events,
+                "failed_events": self.failed_events,
+                "totals": dict(totals) if totals else {},
+                "by_model": [dict(row) for row in by_model],
+            }
+        finally:
+            conn.close()
+
+    def close(self) -> None:
+        """Stop the background writer after queued events drain opportunistically."""
+        if not self._enabled:
+            return
+        self._stop_event.set()
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            self.dropped_events += 1
+            logger.debug("usage_close_signal_dropped", reason="queue_full")
+
+
+class UsageTrackingLLMProvider:
+    """LLMProvider proxy that records usage without blocking LLM responses."""
+
+    def __init__(
+        self,
+        inner: Any,
+        recorder: UsageRecorder,
+        default_provider: str = "unknown",
+        default_model: str = "unknown",
+    ):
+        self.inner = inner
+        self.recorder = recorder
+        self.default_provider = default_provider
+        self.default_model = default_model
+        self._context: ContextVar[Dict[str, Any]] = ContextVar(
+            "omniagent_usage_context",
+            default={},
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.inner, name)
+
+    @property
+    def supports_native_function_calling(self) -> bool:
+        return self.inner.supports_native_function_calling
+
+    def set_usage_context(self, context: Dict[str, Any]) -> Token:
+        return self._context.set(dict(context))
+
+    def reset_usage_context(self, token: Token) -> None:
+        self._context.reset(token)
+
+    async def chat(
+        self,
+        messages: List[Any],
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+        stream: bool = False,
+        tools: Optional[List[Dict]] = None,
+    ) -> Any:
+        response = await self.inner.chat(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=stream,
+            tools=tools,
+        )
+        response.metadata.setdefault("provider", self.default_provider)
+        response.metadata.setdefault("model", self.default_model)
+        self.recorder.record_response(
+            response,
+            context=self._context.get(),
+            default_provider=self.default_provider,
+            default_model=self.default_model,
+        )
+        return response
+
+    async def chat_stream(
+        self,
+        messages: List[Any],
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> AsyncIterator[str]:
+        async for chunk in self.inner.chat_stream(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        ):
+            yield chunk

--- a/omniagent/cli/chat.py
+++ b/omniagent/cli/chat.py
@@ -31,21 +31,31 @@ _prompt_executor = ThreadPoolExecutor(max_workers=1)
 class ChatSession:
     """Interactive chat session."""
 
-    def __init__(self, work_dir: Optional[Path] = None, verbose: bool = False, provider: Optional[str] = None):
+    def __init__(
+        self,
+        work_dir: Optional[Path] = None,
+        verbose: bool = False,
+        provider: Optional[str] = None,
+        config_path: Optional[Path] = None,
+    ):
         """Initialize chat session."""
         self.work_dir = work_dir or Path.cwd()
-        self.config = load_config()  # Load from file or defaults with env vars
+        self.config = load_config(config_path)  # Load from file or defaults with env vars
         self.agent: Optional[ReflexionAgent] = None
         self.verbose = verbose
 
-        # Override provider if specified via CLI
-        if provider and provider in (self.config.providers or {}):
+        # Override provider key if specified via CLI.
+        if provider:
+            providers = self.config.providers or {}
+            if provider not in providers and provider not in {
+                "deepseek", "openai", "anthropic", "ollama", "gemini", "openrouter", "vllm", "sglang", "openai-compatible", "custom"
+            }:
+                raise ValueError(f"Unknown provider key '{provider}'. Add providers.{provider} to config.yaml first.")
             self.config.agent.model_provider = provider
-            provider_cfg = self.config.providers[provider]
-            if provider_cfg.model_id:
-                self.config.agent.model_id = provider_cfg.model_id
-            if provider_cfg.api_url:
-                self.config.agent.api_url = provider_cfg.api_url
+            provider_cfg = providers.get(provider)
+            if provider_cfg:
+                if provider_cfg.api_url:
+                    self.config.agent.api_url = provider_cfg.api_url
         self.session_id: Optional[str] = None
 
         # Logging: file always enabled, console controlled by --verbose
@@ -482,12 +492,15 @@ class ChatSession:
     "--provider",
     type=str,
     default=None,
-    help="LLM provider override (e.g. deepseek, openai)",
+    help="Provider key override (e.g. deepseek, openai, byr)",
 )
-def chat(work_dir: Optional[str], verbose: bool, provider: Optional[str]):
+@click.pass_context
+def chat(ctx: click.Context, work_dir: Optional[str], verbose: bool, provider: Optional[str]):
     """Start an interactive chat session with OmniAgent."""
     work_dir_path = Path(work_dir) if work_dir else Path.cwd()
-    session = ChatSession(work_dir=work_dir_path, verbose=verbose, provider=provider)
+    config_path_raw = ctx.obj.get("config_path") if ctx.obj else None
+    config_path = Path(config_path_raw) if config_path_raw else None
+    session = ChatSession(work_dir=work_dir_path, verbose=verbose, provider=provider, config_path=config_path)
 
     try:
         asyncio.run(session.start())

--- a/omniagent/cli/main.py
+++ b/omniagent/cli/main.py
@@ -276,6 +276,14 @@ def onboard(ctx: click.Context) -> None:
             "host": config_obj.gateway.host,
             "port": config_obj.gateway.port,
             "session_timeout": config_obj.gateway.session_timeout,
+            "usage_summary_max_days": config_obj.gateway.usage_summary_max_days,
+        },
+        "usage": {
+            "pricing_catalog_enabled": config_obj.usage.pricing_catalog_enabled,
+            "pricing_catalog_url": config_obj.usage.pricing_catalog_url,
+            "pricing_cache_ttl_seconds": config_obj.usage.pricing_cache_ttl_seconds,
+            "pricing_request_timeout_seconds": config_obj.usage.pricing_request_timeout_seconds,
+            "pricing_overrides": config_obj.usage.pricing_overrides,
         },
         "tools": {
             "profile": config_obj.tools.profile,

--- a/omniagent/cli/main.py
+++ b/omniagent/cli/main.py
@@ -26,11 +26,11 @@ def main(ctx: click.Context, config: Path) -> None:
     3. Self-Evolution: RLAIF, Self-Improving, Skill Management
     """
     ctx.ensure_object(dict)
+    ctx.obj["config_path"] = str(config) if config else None
 
     # Load config
     try:
         ctx.obj["config"] = load_config(config)
-        ctx.obj["config_path"] = str(config) if config else None
     except Exception as e:
         click.echo(f"Error loading config: {e}", err=True)
         ctx.obj["config"] = get_default_config()
@@ -93,7 +93,8 @@ def serve(ctx: click.Context, host: str, port: int, verbose: bool) -> None:
     agent = ReflexionAgent(config)
 
     # Create and run server
-    server = GatewayServer(config, agent=agent)
+    config_path = Path(ctx.obj["config_path"]) if ctx.obj.get("config_path") else None
+    server = GatewayServer(config, agent=agent, config_path=config_path)
 
     # Set agent handler
     async def agent_handler(message):
@@ -161,41 +162,49 @@ def onboard(ctx: click.Context) -> None:
 
     config_obj = ctx.obj["config"]
 
-    # --- Step 1: Choose LLM provider ---
-    providers = [
+    # --- Step 1: Choose LLM provider implementation ---
+    provider_types = [
         ("deepseek", "DeepSeek (e.g., deepseek-chat)"),
         ("openai", "OpenAI (e.g., gpt-4o)"),
         ("anthropic", "Anthropic (e.g., claude-sonnet-4-20250514)"),
         ("ollama", "Ollama (e.g., llama3)"),
         ("gemini", "Google Gemini (e.g., gemini-2.0-flash)"),
         ("openrouter", "OpenRouter (e.g., openai/gpt-4o)"),
-        ("custom", "Custom OpenAI-compatible endpoint"),
+        ("openai-compatible", "OpenAI-compatible endpoint"),
     ]
+    active_provider_key = config_obj.agent.model_provider
+    active_provider_cfg = (config_obj.providers or {}).get(active_provider_key)
+    active_api_type = active_provider_cfg.api_type if active_provider_cfg and active_provider_cfg.api_type else active_provider_key
 
-    click.echo("Step 1/5: Choose LLM Provider")
+    click.echo("Step 1/5: Choose LLM API Type")
     click.echo("-" * 40)
-    for i, (key, desc) in enumerate(providers, 1):
-        default = " (current)" if config_obj.agent.model_provider == key else ""
+    for i, (key, desc) in enumerate(provider_types, 1):
+        default = " (current)" if active_api_type == key else ""
         click.echo(f"  {i}. {desc}{default}")
 
     choice = click.prompt(
-        "\n  Select provider",
-        type=click.IntRange(1, len(providers)),
-        default=next((i for i, (k, _) in enumerate(providers, 1) if k == config_obj.agent.model_provider), 1),
+        "\n  Select API type",
+        type=click.IntRange(1, len(provider_types)),
+        default=next((i for i, (k, _) in enumerate(provider_types, 1) if k == active_api_type), 1),
     )
-    selected_provider, selected_desc = providers[choice - 1]
+    selected_api_type, selected_desc = provider_types[choice - 1]
     click.echo(f"  → {selected_desc}")
 
     # --- Step 2: Provider-specific config ---
     provider_api_url = None
+    selected_provider = selected_api_type
 
-    if selected_provider == "custom":
-        click.echo(f"\nStep 2/5: Custom Provider Settings")
+    if selected_api_type == "openai-compatible":
+        click.echo(f"\nStep 2/5: OpenAI-compatible Provider Settings")
         click.echo("-" * 40)
+        selected_provider = click.prompt(
+            "  Provider key/name",
+            default=active_provider_key if active_api_type == "openai-compatible" else "openai-compatible-provider",
+        )
         provider_api_url = click.prompt("  API Base URL", type=str)
-        click.echo(f"  → {provider_api_url}")
+        click.echo(f"  → {selected_provider} ({provider_api_url})")
     else:
-        click.echo(f"\nStep 2/5: (skipped — using {selected_desc} defaults)")
+        click.echo(f"\nStep 2/5: (skipped — provider key will be {selected_provider})")
 
     # --- Step 3: Enter API key ---
     click.echo(f"\nStep 3/5: API Key")
@@ -208,9 +217,9 @@ def onboard(ctx: click.Context) -> None:
         "ollama": None,
         "gemini": "GOOGLE_API_KEY",
         "openrouter": "OPENROUTER_API_KEY",
-        "custom": None,
+        "openai-compatible": None,
     }
-    env_var = env_var_map.get(selected_provider)
+    env_var = env_var_map.get(selected_api_type)
     existing_key = config_obj.api_key or (os.getenv(env_var) if env_var else None)
 
     if existing_key:
@@ -218,7 +227,7 @@ def onboard(ctx: click.Context) -> None:
         use_existing = click.confirm("  Use existing key?", default=True)
         api_key = existing_key if use_existing else click.prompt("  Enter API key")
     else:
-        api_key = click.prompt("  Enter API key" if selected_provider != "ollama" else "  API key (usually empty for Ollama)", default="", show_default=False)
+        api_key = click.prompt("  Enter API key" if selected_api_type != "ollama" else "  API key (usually empty for Ollama)", default="", show_default=False)
 
     # --- Step 4: Choose model ---
     click.echo(f"\nStep 4/5: Model ID")
@@ -233,12 +242,12 @@ def onboard(ctx: click.Context) -> None:
         "openrouter": "openai/gpt-4o",
     }
 
-    if selected_provider == "custom":
+    if selected_api_type == "openai-compatible":
         model_id = click.prompt("  Model ID")
-    elif selected_provider == "ollama":
+    elif selected_api_type == "ollama":
         model_id = click.prompt("  Model name", default=default_models.get("ollama", "llama3"))
     else:
-        default_model = default_models.get(selected_provider, "")
+        default_model = default_models.get(selected_api_type, "")
         use_default = click.confirm(f"  Use default model '{default_model}'?", default=True)
         model_id = default_model if use_default else click.prompt("  Model name")
 
@@ -256,8 +265,12 @@ def onboard(ctx: click.Context) -> None:
         click.echo("  Cancelled. No changes made.")
         return
 
-    # Build provider config dict (providers block for extensibility)
+    # Build provider config dict. Built-in provider keys infer api_type from the
+    # key for compatibility with earlier configs; named OpenAI-compatible
+    # providers declare api_type so the runtime uses the OpenAI-compatible client.
     provider_data = {"api_key": api_key, "model_id": model_id}
+    if selected_api_type == "openai-compatible":
+        provider_data["api_type"] = "openai-compatible"
     if provider_api_url:
         provider_data["api_url"] = provider_api_url
 

--- a/omniagent/config/models.py
+++ b/omniagent/config/models.py
@@ -3,10 +3,48 @@
 import os
 from typing import Any, Dict, List, Literal, Optional
 from pathlib import Path
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 _ALLOWED_PRICING_OVERRIDE_RATES = {"input", "output", "cache_read"}
+_PROVIDER_API_TYPES = {
+    "deepseek",
+    "openai",
+    "anthropic",
+    "ollama",
+    "gemini",
+    "openrouter",
+    "vllm",
+    "sglang",
+    "openai-compatible",
+}
+_API_TYPE_ALIASES = {
+    "custom": "openai-compatible",
+    "openai_compatible": "openai-compatible",
+}
+
+
+def _normalize_api_type(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    return _API_TYPE_ALIASES.get(normalized, normalized)
+
+
+def _ensure_supported_api_type(api_type: Optional[str]) -> Optional[str]:
+    if api_type is None:
+        return None
+    if api_type not in _PROVIDER_API_TYPES:
+        supported = ", ".join(sorted(_PROVIDER_API_TYPES))
+        raise ValueError(f"Unsupported provider api_type {api_type!r}; expected one of: {supported}")
+    return api_type
+
+
+def _default_api_type_for_provider_key(provider_key: str) -> Optional[str]:
+    normalized = _normalize_api_type(provider_key)
+    return normalized if normalized in _PROVIDER_API_TYPES else None
 
 
 class ToolsConfig(BaseModel):
@@ -31,12 +69,16 @@ class ToolsConfig(BaseModel):
 class ProviderConfig(BaseModel):
     """Per-provider configuration (api_key, api_url, default model).
 
-    Used in OmniAgentConfig.providers to define named provider presets
-    that can be selected via agent.model_provider or --provider CLI flag.
+    The providers map key is the provider identity used for selection, usage
+    accounting, and pricing. api_type selects the implementation/parser.
     """
 
     model_config = ConfigDict(extra="allow")
 
+    api_type: Optional[str] = Field(
+        default=None,
+        description="Provider implementation type (deepseek, openai, anthropic, ollama, gemini, openrouter, vllm, sglang, openai-compatible)"
+    )
     api_key: Optional[str] = Field(
         default=None,
         description="API key for this provider"
@@ -49,10 +91,20 @@ class ProviderConfig(BaseModel):
         default=None,
         description="Default model ID for this provider"
     )
-    provider_name: Optional[str] = Field(
-        default=None,
-        description="Provider name used for usage accounting/pricing; defaults to the selected provider"
-    )
+
+    @field_validator("api_type", mode="before")
+    @classmethod
+    def _normalize_provider_api_type(cls, value: Any) -> Optional[str]:
+        return _ensure_supported_api_type(_normalize_api_type(value))
+
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_legacy_provider_name(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            cleaned = dict(value)
+            cleaned.pop("provider_name", None)
+            return cleaned
+        return value
 
 
 class AgentConfig(BaseModel):
@@ -60,9 +112,10 @@ class AgentConfig(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    model_provider: Literal["deepseek", "openai", "anthropic", "ollama", "gemini", "openrouter", "vllm", "sglang", "custom"] = Field(
+    model_provider: str = Field(
         default="deepseek",
-        description="LLM provider (deepseek, openai, anthropic, ollama, gemini, openrouter, vllm, sglang, custom)"
+        min_length=1,
+        description="Active provider key from the providers map"
     )
     model_id: str = Field(
         default="deepseek-chat",
@@ -517,7 +570,7 @@ class GuardianConfig(BaseModel):
 class RLConfig(BaseModel):
     """Configuration for Reinforcement Learning (GRPO) training.
 
-    Only activates when model_provider is "vllm" or "sglang".
+    Only activates when api_type is "vllm" or "sglang".
     Controls the FastAPI proxy, PRM scorer, and rollout worker.
     """
 
@@ -672,7 +725,7 @@ class OmniAgentConfig(BaseModel):
     # Named provider presets
     providers: Dict[str, ProviderConfig] = Field(
         default_factory=dict,
-        description="Named LLM provider configs (api_key, api_url, model)"
+        description="Named LLM provider configs keyed by provider identity"
     )
 
     # Working directory
@@ -773,3 +826,134 @@ class OmniAgentConfig(BaseModel):
         default_factory=ChannelsConfig,
         description="Chat channels configuration"
     )
+
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_provider_layout(cls, value: Any) -> Any:
+        """Migrate legacy provider aliases into provider-key identities."""
+        if not isinstance(value, dict):
+            return value
+
+        data = dict(value)
+        providers = data.get("providers")
+        if providers is None:
+            providers = {}
+        elif not isinstance(providers, dict):
+            return data
+
+        agent = data.get("agent")
+        agent_data = dict(agent) if isinstance(agent, dict) else {}
+        active_provider = agent_data.get("model_provider")
+        normalized_providers: Dict[str, Any] = {}
+        provider_renames: List[tuple[str, str, Optional[str], Optional[str]]] = []
+
+        for raw_key, raw_provider in providers.items():
+            provider_key = str(raw_key)
+            if not isinstance(raw_provider, dict):
+                normalized_providers[provider_key] = raw_provider
+                continue
+
+            provider_data = dict(raw_provider)
+            legacy_name_raw = provider_data.pop("provider_name", None)
+            legacy_name = str(legacy_name_raw).strip() if legacy_name_raw else None
+            api_type = _ensure_supported_api_type(_normalize_api_type(provider_data.get("api_type")))
+            provider_key_api_type = _default_api_type_for_provider_key(provider_key)
+            legacy_name_api_type = _default_api_type_for_provider_key(legacy_name) if legacy_name else None
+            if api_type is not None:
+                provider_data["api_type"] = api_type
+
+            target_key = provider_key
+            if legacy_name and legacy_name != provider_key:
+                conflict = legacy_name in providers or legacy_name in normalized_providers
+                if provider_key_api_type and not conflict:
+                    target_key = legacy_name
+                    if not provider_data.get("api_type"):
+                        provider_data["api_type"] = provider_key_api_type
+                elif not provider_data.get("api_type"):
+                    fallback_api_type = provider_key_api_type or legacy_name_api_type
+                    if fallback_api_type:
+                        provider_data["api_type"] = fallback_api_type
+                provider_renames.append((provider_key, target_key, provider_data.get("model_id"), legacy_name))
+
+            if not provider_data.get("api_type") and not _default_api_type_for_provider_key(target_key):
+                raise ValueError(f"providers.{target_key}.api_type is required for named provider keys")
+
+            normalized_providers[target_key] = provider_data
+            if active_provider == provider_key and target_key != provider_key:
+                agent_data["model_provider"] = target_key
+
+        if agent_data:
+            active_key = str(agent_data.get("model_provider") or "deepseek").strip()
+            active_provider = normalized_providers.get(active_key)
+            has_agent_model = str(agent_data.get("model_id") or "").strip()
+            if not has_agent_model and isinstance(active_provider, dict) and active_provider.get("model_id"):
+                agent_data["model_id"] = active_provider["model_id"]
+            data["agent"] = agent_data
+        data["providers"] = normalized_providers
+        cls._validate_active_provider_key(data, normalized_providers)
+        cls._migrate_pricing_override_keys(data, provider_renames)
+        return data
+
+    @staticmethod
+    def _validate_active_provider_key(data: Dict[str, Any], providers: Dict[str, Any]) -> None:
+        agent = data.get("agent")
+        active_provider = "deepseek"
+        if isinstance(agent, dict):
+            raw_active = agent.get("model_provider")
+            if raw_active is not None:
+                active_provider = str(raw_active).strip()
+
+        if not active_provider:
+            return
+        if active_provider in providers:
+            provider_data = providers[active_provider]
+            if isinstance(provider_data, dict):
+                api_type = _ensure_supported_api_type(_normalize_api_type(provider_data.get("api_type")))
+                if api_type is not None:
+                    provider_data["api_type"] = api_type
+                elif not _default_api_type_for_provider_key(active_provider):
+                    raise ValueError(
+                        f"providers.{active_provider}.api_type is required for active named provider key"
+                    )
+            return
+
+        if _default_api_type_for_provider_key(active_provider):
+            return
+
+        raise ValueError(
+            f"agent.model_provider={active_provider!r} requires providers.{active_provider}.api_type; "
+            "use a built-in provider key or add a provider entry with api_type"
+        )
+
+    @staticmethod
+    def _migrate_pricing_override_keys(
+        data: Dict[str, Any],
+        provider_renames: List[tuple[str, str, Optional[str], Optional[str]]],
+    ) -> None:
+        if not provider_renames:
+            return
+        usage = data.get("usage")
+        if not isinstance(usage, dict):
+            return
+        overrides = usage.get("pricing_overrides")
+        if not isinstance(overrides, dict):
+            return
+
+        migrated = dict(overrides)
+        for old_key, new_key, model_id, legacy_name in provider_renames:
+            if not model_id:
+                continue
+            model_key = str(model_id)
+            destination = f"{new_key}/{model_key}"
+            candidates = [destination, f"{old_key}/{model_key}"]
+            if legacy_name:
+                candidates.insert(0, f"{legacy_name}/{model_key}")
+            for candidate in candidates:
+                if candidate in migrated:
+                    migrated.setdefault(destination, migrated[candidate])
+                    break
+            for candidate in candidates:
+                if candidate != destination:
+                    migrated.pop(candidate, None)
+        usage["pricing_overrides"] = migrated

--- a/omniagent/config/models.py
+++ b/omniagent/config/models.py
@@ -3,7 +3,10 @@
 import os
 from typing import Any, Dict, List, Literal, Optional
 from pathlib import Path
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+_ALLOWED_PRICING_OVERRIDE_RATES = {"input", "output", "cache_read"}
 
 
 class ToolsConfig(BaseModel):
@@ -246,8 +249,29 @@ class UsageConfig(BaseModel):
     )
     pricing_overrides: Dict[str, Dict[str, float]] = Field(
         default_factory=dict,
-        description="Manual pricing overrides keyed by 'provider/model_id' or model_id; values are USD per million tokens"
+        description="Manual pricing overrides keyed by 'provider/model_id'. Supported rates are input, output, and cache_read, in USD per million tokens"
     )
+
+    @field_validator("pricing_overrides", mode="before")
+    @classmethod
+    def _sanitize_pricing_overrides(cls, value: Any) -> Any:
+        """Drop unsupported pricing keys before config is exposed or saved."""
+        if value is None or not isinstance(value, dict):
+            return value
+
+        sanitized: Dict[str, Any] = {}
+        for rule_key, rule in value.items():
+            if not isinstance(rule, dict):
+                sanitized[str(rule_key)] = rule
+                continue
+            filtered = {
+                rate_key: rate
+                for rate_key, rate in rule.items()
+                if rate_key in _ALLOWED_PRICING_OVERRIDE_RATES
+            }
+            if filtered:
+                sanitized[str(rule_key)] = filtered
+        return sanitized
 
 
 class ChannelsConfig(BaseModel):

--- a/omniagent/config/models.py
+++ b/omniagent/config/models.py
@@ -210,6 +210,40 @@ class GatewayConfig(BaseModel):
         gt=0,
         description="Session timeout in seconds"
     )
+    usage_summary_max_days: int = Field(
+        default=365,
+        ge=1,
+        description="Maximum days accepted by /api/usage/summary"
+    )
+
+
+class UsageConfig(BaseModel):
+    """Usage accounting configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    pricing_catalog_enabled: bool = Field(
+        default=True,
+        description="Use the default model pricing catalog for usage cost estimates"
+    )
+    pricing_catalog_url: str = Field(
+        default="https://models.dev/api.json",
+        description="Default model pricing catalog URL"
+    )
+    pricing_cache_ttl_seconds: int = Field(
+        default=900,
+        ge=0,
+        description="Seconds to cache fetched model pricing data"
+    )
+    pricing_request_timeout_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        description="Timeout for fetching default model pricing data"
+    )
+    pricing_overrides: Dict[str, Dict[str, float]] = Field(
+        default_factory=dict,
+        description="Manual pricing overrides keyed by 'provider/model_id' or model_id; values are USD per million tokens"
+    )
 
 
 class ChannelsConfig(BaseModel):
@@ -645,6 +679,11 @@ class OmniAgentConfig(BaseModel):
     gateway: GatewayConfig = Field(
         default_factory=GatewayConfig,
         description="Gateway configuration"
+    )
+
+    usage: UsageConfig = Field(
+        default_factory=UsageConfig,
+        description="Usage accounting configuration"
     )
 
     # Feature flags

--- a/omniagent/config/models.py
+++ b/omniagent/config/models.py
@@ -46,6 +46,10 @@ class ProviderConfig(BaseModel):
         default=None,
         description="Default model ID for this provider"
     )
+    provider_name: Optional[str] = Field(
+        default=None,
+        description="Provider name used for usage accounting/pricing; defaults to the selected provider"
+    )
 
 
 class AgentConfig(BaseModel):

--- a/omniagent/config/models.py
+++ b/omniagent/config/models.py
@@ -884,11 +884,6 @@ class OmniAgentConfig(BaseModel):
                 agent_data["model_provider"] = target_key
 
         if agent_data:
-            active_key = str(agent_data.get("model_provider") or "deepseek").strip()
-            active_provider = normalized_providers.get(active_key)
-            has_agent_model = str(agent_data.get("model_id") or "").strip()
-            if not has_agent_model and isinstance(active_provider, dict) and active_provider.get("model_id"):
-                agent_data["model_id"] = active_provider["model_id"]
             data["agent"] = agent_data
         data["providers"] = normalized_providers
         cls._validate_active_provider_key(data, normalized_providers)

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -1,5 +1,6 @@
 """REST API handlers for OmniAgent gateway."""
 
+import errno
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -112,8 +113,15 @@ async def update_config(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # Deep merge
+    # Deep merge. pricing_overrides is a keyed rule map, so replace it as a
+    # whole when provided; otherwise removing a rate in the UI would leave stale
+    # nested keys behind from the old saved config.
     current = ctx.config.model_dump(mode="json")
+    usage_updates = updates.get("usage")
+    if isinstance(usage_updates, dict) and isinstance(usage_updates.get("pricing_overrides"), dict):
+        current_usage = current.get("usage")
+        if isinstance(current_usage, dict):
+            current_usage["pricing_overrides"] = {}
     merged = deep_merge(current, updates)
 
     try:
@@ -121,9 +129,21 @@ async def update_config(request: web.Request) -> web.Response:
     except Exception as e:
         return web.json_response({"error": f"Invalid config: {e}"}, status=400)
 
-    # Save to disk
+    # Save to disk when possible. Docker deployments commonly mount config.yaml
+    # read-only; in that case still apply the change to the live runtime and tell
+    # the UI it is not persisted across reload/restart.
+    persisted = True
+    warning = None
     try:
         save_config(new_config)
+    except OSError as e:
+        if e.errno in (errno.EROFS, errno.EACCES, errno.EPERM):
+            persisted = False
+            warning = "Config file is read-only; changes were applied to the running process only. Edit config.yaml and Reload from Disk to persist them."
+            logger.warning("config_save_read_only", error=str(e))
+        else:
+            logger.error("config_save_error", error=str(e))
+            return web.json_response({"error": f"Failed to save config: {e}"}, status=500)
     except Exception as e:
         logger.error("config_save_error", error=str(e))
         return web.json_response({"error": f"Failed to save config: {e}"}, status=500)
@@ -135,7 +155,14 @@ async def update_config(request: web.Request) -> web.Response:
 
     result = new_config.model_dump(mode="json")
     _mask_sensitive_fields(result)
-    return web.json_response({"status": "updated", "config": result})
+    response = {
+        "status": "updated" if persisted else "updated_runtime_only",
+        "persisted": persisted,
+        "config": result,
+    }
+    if warning:
+        response["warning"] = warning
+    return web.json_response(response)
 
 
 async def reload_config_handler(request: web.Request) -> web.Response:

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -128,10 +128,10 @@ async def update_config(request: web.Request) -> web.Response:
         logger.error("config_save_error", error=str(e))
         return web.json_response({"error": f"Failed to save config: {e}"}, status=500)
 
-    # Update in-memory
+    # Update in-memory and refresh the running agent runtime.
     ctx.config = new_config
     if ctx.agent is not None:
-        ctx.agent.config = new_config
+        ctx.agent.apply_config(new_config)
 
     result = new_config.model_dump(mode="json")
     _mask_sensitive_fields(result)
@@ -151,7 +151,7 @@ async def reload_config_handler(request: web.Request) -> web.Response:
 
     ctx.config = reloaded
     if ctx.agent is not None:
-        ctx.agent.config = reloaded
+        ctx.agent.apply_config(reloaded)
 
     return web.json_response({"status": "reloaded"})
 
@@ -315,7 +315,7 @@ async def get_health(request: web.Request) -> web.Response:
             "model_id": ctx.agent.config.agent.model_id if ctx.agent.config else "unknown",
             "is_streaming": agent_state.is_streaming,
             "current_iteration": agent_state.iteration,
-            "pending_tool_calls": agent_state.pending_tool_calls,
+            "pending_tool_calls": sorted(agent_state.pending_tool_calls),
             "total_tool_calls": agent_state.total_tool_calls,
             "error": agent_state.error,
         }

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -1,14 +1,17 @@
 """REST API handlers for OmniAgent gateway."""
 
 import errno
+import json
 import time
+
+import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from aiohttp import web
 
-from omniagent.config.loader import DEFAULT_CONFIG_PATH, deep_merge, load_config, save_config
+from omniagent.config.loader import DEFAULT_CONFIG_PATH, deep_merge, load_config
 from omniagent.infra import get_logger
 from omniagent.config.models import OmniAgentConfig
 from omniagent.agents.usage import (
@@ -63,6 +66,80 @@ def _contains_sensitive(updates: dict) -> List[str]:
     return found
 
 
+def _load_raw_config_for_preserve(config_path: Optional[Path]) -> Optional[dict]:
+    """Load raw config without env substitution so secrets/placeholders survive saves."""
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return None
+    if path.suffix in (".yaml", ".yml"):
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    elif path.suffix == ".json":
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _raw_provider_for_key(raw_providers: dict, provider_key: str) -> Optional[dict]:
+    raw_provider = raw_providers.get(provider_key)
+    if isinstance(raw_provider, dict):
+        return raw_provider
+    for candidate in raw_providers.values():
+        if not isinstance(candidate, dict):
+            continue
+        legacy_name = candidate.get("provider_name")
+        if legacy_name is not None and str(legacy_name).strip() == provider_key:
+            return candidate
+    return None
+
+
+def _restore_sensitive_for_save(data: dict, raw_config: Optional[dict]) -> None:
+    """Restore raw sensitive values/placeholders before persisting runtime config."""
+    raw_config = raw_config or {}
+
+    for name in _SENSITIVE_FIELDS:
+        if name in raw_config:
+            data[name] = raw_config[name]
+        elif name in data:
+            data[name] = None
+
+    providers = data.get("providers")
+    raw_providers = raw_config.get("providers")
+    if not isinstance(providers, dict):
+        return
+    if not isinstance(raw_providers, dict):
+        raw_providers = {}
+
+    for provider_key, provider_data in providers.items():
+        if not isinstance(provider_data, dict):
+            continue
+        raw_provider = _raw_provider_for_key(raw_providers, str(provider_key))
+        if isinstance(raw_provider, dict) and "api_key" in raw_provider:
+            provider_data["api_key"] = raw_provider["api_key"]
+        elif "api_key" in provider_data:
+            provider_data["api_key"] = None
+
+
+def _save_config_preserving_sensitive(config: OmniAgentConfig, config_path: Optional[Path]) -> None:
+    """Save config while keeping env-resolved secrets out of the file."""
+    path = config_path or DEFAULT_CONFIG_PATH
+    raw_config = _load_raw_config_for_preserve(path)
+    data = config.model_dump(mode="json")
+    _restore_sensitive_for_save(data, raw_config)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix in (".yaml", ".yml"):
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False)
+    elif path.suffix == ".json":
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    else:
+        raise ValueError(f"Unsupported config format: {path.suffix}")
+
+
 # ── API Context ────────────────────────────────────────────────
 
 
@@ -74,6 +151,7 @@ class APIContext:
     session_manager: Optional["SessionManager"] = None
     config: Optional["OmniAgentConfig"] = None
     channel_manager: Optional["ChannelManager"] = None
+    config_path: Optional[Path] = None
     start_time: float = field(default_factory=time.time)
 
 
@@ -127,31 +205,48 @@ async def update_config(request: web.Request) -> web.Response:
     try:
         new_config = OmniAgentConfig(**merged)
     except Exception as e:
-        return web.json_response({"error": f"Invalid config: {e}"}, status=400)
+        logger.warning("config_validation_error", error_type=type(e).__name__)
+        return web.json_response({"error": "Invalid config", "code": "invalid_config"}, status=400)
 
-    # Save to disk when possible. Docker deployments commonly mount config.yaml
-    # read-only; in that case still apply the change to the live runtime and tell
-    # the UI it is not persisted across reload/restart.
+    # Apply first so invalid runtime provider choices cannot be persisted. Docker
+    # deployments commonly mount config.yaml read-only; after a successful runtime
+    # apply, save when possible and report runtime-only changes when the mount is ro.
+    old_config = ctx.config
+    try:
+        if ctx.agent is not None:
+            ctx.agent.apply_config(new_config)
+    except Exception as e:
+        logger.warning("config_apply_error", error_type=type(e).__name__)
+        return web.json_response({"error": "Failed to apply config", "code": "config_apply_failed"}, status=400)
+
     persisted = True
     warning = None
     try:
-        save_config(new_config)
+        _save_config_preserving_sensitive(new_config, ctx.config_path)
     except OSError as e:
         if e.errno in (errno.EROFS, errno.EACCES, errno.EPERM):
             persisted = False
             warning = "Config file is read-only; changes were applied to the running process only. Edit config.yaml and Reload from Disk to persist them."
-            logger.warning("config_save_read_only", error=str(e))
+            logger.warning("config_save_read_only", error_type=type(e).__name__, errno=e.errno)
         else:
-            logger.error("config_save_error", error=str(e))
-            return web.json_response({"error": f"Failed to save config: {e}"}, status=500)
+            if ctx.agent is not None:
+                try:
+                    ctx.agent.apply_config(old_config)
+                except Exception as rollback_error:
+                    logger.error("config_apply_rollback_error", error_type=type(rollback_error).__name__)
+            logger.error("config_save_error", error_type=type(e).__name__)
+            return web.json_response({"error": "Failed to save config", "code": "config_save_failed"}, status=500)
     except Exception as e:
-        logger.error("config_save_error", error=str(e))
-        return web.json_response({"error": f"Failed to save config: {e}"}, status=500)
+        if ctx.agent is not None:
+            try:
+                ctx.agent.apply_config(old_config)
+            except Exception as rollback_error:
+                logger.error("config_apply_rollback_error", error_type=type(rollback_error).__name__)
+        logger.error("config_save_error", error_type=type(e).__name__)
+        return web.json_response({"error": "Failed to save config", "code": "config_save_failed"}, status=500)
 
-    # Update in-memory and refresh the running agent runtime.
+    # Update in-memory after both validation and runtime application succeed.
     ctx.config = new_config
-    if ctx.agent is not None:
-        ctx.agent.apply_config(new_config)
 
     result = new_config.model_dump(mode="json")
     _mask_sensitive_fields(result)
@@ -172,13 +267,14 @@ async def reload_config_handler(request: web.Request) -> web.Response:
         return web.json_response({"error": "Config not loaded"}, status=503)
 
     try:
-        reloaded = load_config(DEFAULT_CONFIG_PATH)
+        reloaded = load_config(ctx.config_path or DEFAULT_CONFIG_PATH)
+        if ctx.agent is not None:
+            ctx.agent.apply_config(reloaded)
     except Exception as e:
-        return web.json_response({"error": f"Failed to reload: {e}"}, status=500)
+        logger.warning("config_reload_error", error_type=type(e).__name__)
+        return web.json_response({"error": "Failed to reload config", "code": "config_reload_failed"}, status=500)
 
     ctx.config = reloaded
-    if ctx.agent is not None:
-        ctx.agent.apply_config(reloaded)
 
     return web.json_response({"status": "reloaded"})
 

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -122,11 +122,53 @@ def _restore_sensitive_for_save(data: dict, raw_config: Optional[dict]) -> None:
             provider_data["api_key"] = None
 
 
+def _agent_model_is_explicit(config: OmniAgentConfig) -> bool:
+    agent_model = str(config.agent.model_id or "").strip()
+    agent_fields_set = getattr(config.agent, "model_fields_set", set())
+    return bool(agent_model) and "model_id" in agent_fields_set
+
+
+def _effective_agent_model_id(config: OmniAgentConfig, runtime_agent=None) -> str:
+    if _agent_model_is_explicit(config):
+        return config.agent.model_id
+    usage_model_id = getattr(runtime_agent, "usage_model_id", None)
+    if usage_model_id:
+        return str(usage_model_id)
+    provider_cfg = config.providers.get(config.agent.model_provider) if config.providers else None
+    provider_model = getattr(provider_cfg, "model_id", None) if provider_cfg else None
+    return str(provider_model or config.agent.model_id)
+
+
+def _config_response_data(config: OmniAgentConfig, runtime_agent=None) -> dict:
+    data = config.model_dump(mode="json")
+    agent_data = data.setdefault("agent", {})
+    if isinstance(agent_data, dict):
+        agent_data["model_id"] = _effective_agent_model_id(config, runtime_agent)
+    _mask_sensitive_fields(data)
+    return data
+
+
+def _drop_implicit_agent_model(data: dict, config: OmniAgentConfig) -> None:
+    if _agent_model_is_explicit(config):
+        return
+    agent_data = data.get("agent")
+    if isinstance(agent_data, dict):
+        agent_data.pop("model_id", None)
+
+
+def _preserve_implicit_agent_model(current: dict, updates: dict, config: OmniAgentConfig) -> dict:
+    if _agent_model_is_explicit(config):
+        return updates
+    _drop_implicit_agent_model(current, config)
+    return updates
+
+
 def _save_config_preserving_sensitive(config: OmniAgentConfig, config_path: Optional[Path]) -> None:
     """Save config while keeping env-resolved secrets out of the file."""
     path = config_path or DEFAULT_CONFIG_PATH
     raw_config = _load_raw_config_for_preserve(path)
     data = config.model_dump(mode="json")
+    _drop_implicit_agent_model(data, config)
     _restore_sensitive_for_save(data, raw_config)
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -164,9 +206,7 @@ async def get_config(request: web.Request) -> web.Response:
     if ctx.config is None:
         return web.json_response({"error": "Config not loaded"}, status=503)
 
-    data = ctx.config.model_dump(mode="json")
-    _mask_sensitive_fields(data)
-    return web.json_response(data)
+    return web.json_response(_config_response_data(ctx.config, ctx.agent))
 
 
 async def update_config(request: web.Request) -> web.Response:
@@ -195,6 +235,7 @@ async def update_config(request: web.Request) -> web.Response:
     # whole when provided; otherwise removing a rate in the UI would leave stale
     # nested keys behind from the old saved config.
     current = ctx.config.model_dump(mode="json")
+    updates = _preserve_implicit_agent_model(current, updates, ctx.config)
     usage_updates = updates.get("usage")
     if isinstance(usage_updates, dict) and isinstance(usage_updates.get("pricing_overrides"), dict):
         current_usage = current.get("usage")
@@ -248,8 +289,7 @@ async def update_config(request: web.Request) -> web.Response:
     # Update in-memory after both validation and runtime application succeed.
     ctx.config = new_config
 
-    result = new_config.model_dump(mode="json")
-    _mask_sensitive_fields(result)
+    result = _config_response_data(new_config, ctx.agent)
     response = {
         "status": "updated" if persisted else "updated_runtime_only",
         "persisted": persisted,

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -10,6 +10,11 @@ from aiohttp import web
 from omniagent.config.loader import DEFAULT_CONFIG_PATH, deep_merge, load_config, save_config
 from omniagent.infra import get_logger
 from omniagent.config.models import OmniAgentConfig
+from omniagent.agents.usage import (
+    enrich_usage_summary_with_pricing,
+    load_models_dev_catalog,
+    load_models_dev_pricing_catalog,
+)
 
 if TYPE_CHECKING:
     from omniagent.agents.reflexion import ReflexionAgent
@@ -17,6 +22,8 @@ if TYPE_CHECKING:
     from omniagent.channels.manager import ChannelManager
 
 logger = get_logger(__name__)
+
+MAX_USAGE_SUMMARY_LIMIT = 500
 
 # ── Sensitive field masking ────────────────────────────────────
 
@@ -368,6 +375,99 @@ async def get_health(request: web.Request) -> web.Response:
     return web.json_response(status)
 
 
+def _get_usage_config(ctx: APIContext):
+    return ctx.config.usage if ctx.config is not None else OmniAgentConfig().usage
+
+
+async def get_usage_summary(request: web.Request) -> web.Response:
+    """GET /api/usage/summary -- aggregate LLM usage by provider/model."""
+    ctx: APIContext = request.app["api_ctx"]
+    recorder = getattr(ctx.agent, "usage_recorder", None) if ctx.agent is not None else None
+    if recorder is None:
+        return web.json_response({
+            "usage": {
+                "totals": {},
+                "by_model": [],
+                "dropped_events": 0,
+                "failed_events": 0,
+            }
+        })
+
+    if ctx.config is not None:
+        usage_summary_max_days = ctx.config.gateway.usage_summary_max_days
+    else:
+        usage_summary_max_days = OmniAgentConfig().gateway.usage_summary_max_days
+
+    days = None
+    days_raw = request.query.get("days")
+    if days_raw:
+        try:
+            days = int(days_raw)
+        except ValueError:
+            return web.json_response({"error": "days must be an integer"}, status=400)
+        if days <= 0:
+            return web.json_response({"error": "days must be positive"}, status=400)
+        if days > usage_summary_max_days:
+            return web.json_response(
+                {"error": f"days must be <= {usage_summary_max_days}"},
+                status=400,
+            )
+
+    limit = 50
+    limit_raw = request.query.get("limit")
+    if limit_raw:
+        try:
+            limit = int(limit_raw)
+        except ValueError:
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+        if limit <= 0:
+            return web.json_response({"error": "limit must be positive"}, status=400)
+        if limit > MAX_USAGE_SUMMARY_LIMIT:
+            limit = MAX_USAGE_SUMMARY_LIMIT
+
+    usage_config = _get_usage_config(ctx)
+
+    try:
+        summary = recorder.summary(days=days, limit=limit)
+        pricing_catalog = {}
+        if usage_config.pricing_catalog_enabled:
+            pricing_catalog = load_models_dev_pricing_catalog(
+                source_url=usage_config.pricing_catalog_url,
+                timeout_seconds=usage_config.pricing_request_timeout_seconds,
+                cache_ttl_seconds=usage_config.pricing_cache_ttl_seconds,
+            )
+        summary = enrich_usage_summary_with_pricing(
+            summary,
+            pricing_catalog,
+            overrides=usage_config.pricing_overrides,
+        )
+    except Exception as e:
+        logger.warning("usage_summary_failed", error=str(e))
+        return web.json_response({"error": "Failed to load usage summary"}, status=500)
+
+    return web.json_response({"usage": summary})
+
+
+async def get_external_models(request: web.Request) -> web.Response:
+    """GET /api/admin/models/external -- proxy the external model catalog."""
+    ctx: APIContext = request.app["api_ctx"]
+    usage_config = _get_usage_config(ctx)
+
+    try:
+        catalog = load_models_dev_catalog(
+            source_url=usage_config.pricing_catalog_url,
+            timeout_seconds=usage_config.pricing_request_timeout_seconds,
+            cache_ttl_seconds=usage_config.pricing_cache_ttl_seconds,
+        )
+    except Exception as e:
+        logger.warning("external_models_failed", error=str(e))
+        return web.json_response({"error": "Failed to load external models"}, status=502)
+
+    if not catalog:
+        return web.json_response({"error": "External models unavailable"}, status=502)
+    return web.json_response(catalog)
+
+
 # ── Skills Handlers ───────────────────────────────────────────
 
 
@@ -525,6 +625,8 @@ def create_api_router(ctx: APIContext) -> List[web.RouteDef]:
         web.delete("/api/sessions/{session_id}", delete_session),
         # Health
         web.get("/api/health", get_health),
+        web.get("/api/usage/summary", get_usage_summary),
+        web.get("/api/admin/models/external", get_external_models),
         # Skills
         web.get("/api/skills", list_skills),
         web.get("/api/skills/{skill_name}", get_skill),

--- a/omniagent/gateway/server.py
+++ b/omniagent/gateway/server.py
@@ -22,16 +22,23 @@ logger = get_logger(__name__)
 class GatewayServer:
     """WebSocket gateway server with optional channel support."""
 
-    def __init__(self, config: OmniAgentConfig, agent: Optional["ReflexionAgent"] = None):
+    def __init__(
+        self,
+        config: OmniAgentConfig,
+        agent: Optional["ReflexionAgent"] = None,
+        config_path: Optional[Path] = None,
+    ):
         """
         Initialize gateway server.
 
         Args:
             config: OmniAgent configuration
             agent: Optional ReflexionAgent instance for API endpoints
+            config_path: Config file path used for API save/reload
         """
         self.config = config
         self.agent = agent
+        self.config_path = config_path
         self.host = config.gateway.host
         self.port = config.gateway.port
         self._start_time = time.time()
@@ -66,6 +73,7 @@ class GatewayServer:
             agent=agent,
             session_manager=self.session_manager,
             config=self.config,
+            config_path=self.config_path,
         )
         self.app["api_ctx"] = self.ctx
         self.app.router.add_routes(create_api_router(self.ctx))

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -549,6 +549,29 @@ body {
 .card .stat-row .stat-label { color: var(--text-secondary); }
 .card .stat-row .stat-value { color: var(--text-primary); font-weight: 500; }
 .usage-card { grid-column: 1 / -1; }
+.usage-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.usage-range-select,
+.usage-days-input {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.usage-days-input { width: 90px; }
+.usage-custom-days {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
 .usage-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1019,7 +1042,19 @@ body {
   <div id="panel-dashboard" class="panel">
     <div class="panel-header">
       <h2>Dashboard</h2>
-      <div class="panel-actions">
+      <div class="panel-actions usage-controls">
+        <select id="usage-range-select" class="usage-range-select" onchange="panels.dashboard.setUsageRange(this.value)">
+          <option value="today">Today</option>
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="365">Last year</option>
+          <option value="custom">Custom days</option>
+        </select>
+        <span id="usage-custom-days" class="usage-custom-days">
+          <span>Last</span>
+          <input id="usage-days-input" class="usage-days-input" type="number" min="1" step="1" value="7" onchange="panels.dashboard.setCustomDays(this.value)">
+          <span>days</span>
+        </span>
         <button class="btn btn-sm" onclick="panels.dashboard.load()">Refresh</button>
       </div>
     </div>
@@ -1675,12 +1710,53 @@ const panels = {
   // ── Dashboard ───────────────────
   dashboard: {
     _interval: null,
-    onActivate() { this.load(); this._interval = setInterval(() => this.load(), 10000); },
+    _usageRange: 'today',
+    _customDays: '7',
+    onActivate() { this.syncUsageControls(); this.load(); this._interval = setInterval(() => this.load(), 10000); },
     onDeactivate() { clearInterval(this._interval); },
+    syncUsageControls() {
+      const select = document.getElementById('usage-range-select');
+      const custom = document.getElementById('usage-custom-days');
+      const input = document.getElementById('usage-days-input');
+      if (select) select.value = this._usageRange;
+      if (custom) custom.style.display = this._usageRange === 'custom' ? 'flex' : 'none';
+      if (input) input.value = this._customDays;
+    },
+    setUsageRange(value) {
+      this._usageRange = value || 'today';
+      this.syncUsageControls();
+      this.load();
+    },
+    setCustomDays(value) {
+      this._customDays = value || '7';
+      this.load();
+    },
+    usageSummaryPath() {
+      const range = this._usageRange || 'today';
+      if (range === 'today') return '/usage/summary';
+      const days = range === 'custom' ? Math.max(1, parseInt(this._customDays || '7', 10) || 7) : parseInt(range, 10);
+      return `/usage/summary?days=${days}`;
+    },
+    usageRangeTitle(usage = {}) {
+      const labels = {
+        today: 'Today',
+        '7': 'Last 7 Days',
+        '30': 'Last 30 Days',
+        '365': 'Last Year',
+        last_7_days: 'Last 7 Days',
+        last_30_days: 'Last 30 Days',
+        last_365_days: 'Last Year',
+      };
+      if (this._usageRange === 'custom') {
+        return `Last ${Math.max(1, parseInt(this._customDays || '7', 10) || 7)} Days`;
+      }
+      return labels[usage.window] || labels[this._usageRange] || 'Selected Range';
+    },
     async load() {
+      const usagePath = this.usageSummaryPath();
       const [healthResult, usageResult] = await Promise.all([
         api.get('/health'),
-        api.get('/usage/summary'),
+        api.get(usagePath),
       ]);
       if (!healthResult.ok) return;
       const h = healthResult.data;
@@ -1755,12 +1831,13 @@ const panels = {
       cards.innerHTML = html;
     },
     renderUsageCard(result) {
-      let html = '<div class="card usage-card"><h3>Today\'s Usage by Provider / Model</h3>';
+      const usage = result?.data?.usage || {};
+      const rangeTitle = this.usageRangeTitle(usage);
+      let html = `<div class="card usage-card"><h3>${escapeHtml(rangeTitle)} Usage by Provider / Model</h3>`;
       if (!result?.ok) {
         return `${html}<div class="usage-empty">Usage summary is unavailable right now.</div></div>`;
       }
 
-      const usage = result.data.usage || {};
       const totals = usage.totals || {};
       const rows = Array.isArray(usage.by_model) ? usage.by_model : [];
       const pricedModels = Number(totals.priced_models || 0);
@@ -1779,7 +1856,7 @@ const panels = {
       html += '</div>';
 
       if (!rows.length) {
-        html += '<div class="usage-empty">No LLM usage has been recorded for today yet.</div>';
+        html += '<div class="usage-empty">No LLM usage has been recorded for this range yet.</div>';
       } else {
         html += '<div class="usage-table-wrap"><table class="usage-table"><thead><tr>';
         html += '<th>Provider</th><th>Model</th><th>Total</th><th>Input</th><th>Cache Input</th><th>Output</th><th>Cache Hit</th><th>Cost</th><th>Pricing</th>';

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -865,7 +865,7 @@ body {
         <summary>Providers</summary>
         <div class="form-body">
           <div class="provider-note">
-            Docker/file-mounted config mode: edit host <code>config.yaml</code> (mounted as <code>~/.omniagent/config.yaml</code>), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the mounted config file or environment variables.
+            File-mounted config mode: edit host <code>config.yaml</code> (mounted as <code>~/.omniagent/config.yaml</code>), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the mounted config file or environment variables.
           </div>
           <div class="provider-list" id="providers-list"></div>
         </div>

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -467,6 +467,46 @@ body {
   padding: 1px 5px;
   border-radius: 4px;
 }
+.pricing-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
+}
+.pricing-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.pricing-field label {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.pricing-field input[type="number"] {
+  width: 100%;
+  padding: 7px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+.pricing-field input[type="number"]:focus { border-color: var(--accent); }
+.pricing-field small {
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.4;
+}
 .secret-mask { color: var(--warning); }
 .form-actions-bar {
   display: flex; gap: 8px; padding: 16px 24px;
@@ -481,6 +521,7 @@ body {
   z-index: 1000;
 }
 .toast-success { background: rgba(78,205,196,0.9); color: #0f0f1a; }
+.toast-warning { background: rgba(255,230,109,0.95); color: #0f0f1a; }
 .toast-error { background: rgba(255,107,107,0.9); color: #fff; }
 @keyframes toast-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 
@@ -507,6 +548,72 @@ body {
 }
 .card .stat-row .stat-label { color: var(--text-secondary); }
 .card .stat-row .stat-value { color: var(--text-primary); font-weight: 500; }
+.usage-card { grid-column: 1 / -1; }
+.usage-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.usage-metric {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.usage-metric-label {
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.usage-metric-value {
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 700;
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.usage-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.usage-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.usage-table th,
+.usage-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.usage-table th {
+  color: var(--text-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.usage-table tr:last-child td { border-bottom: 0; }
+.usage-table td.numeric { text-align: right; font-variant-numeric: tabular-nums; }
+.usage-table td.model-cell { overflow-wrap: anywhere; }
+.usage-note {
+  margin-top: 10px;
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.usage-empty {
+  padding: 12px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -785,11 +892,11 @@ body {
         <div class="form-body">
           <div class="form-row">
             <label>Model Provider</label>
-            <input type="text" id="cfg-model-provider" placeholder="e.g. openai, deepseek">
+            <input type="text" id="cfg-model-provider" placeholder="e.g. openai, deepseek" oninput="panels.settings.renderPricingFromForm()">
           </div>
           <div class="form-row">
             <label>Model ID</label>
-            <input type="text" id="cfg-model-id" placeholder="e.g. gpt-4">
+            <input type="text" id="cfg-model-id" placeholder="e.g. gpt-4" oninput="panels.settings.renderPricingFromForm()">
           </div>
           <div class="form-row">
             <label>Temperature</label>
@@ -865,9 +972,40 @@ body {
         <summary>Providers</summary>
         <div class="form-body">
           <div class="provider-note">
-            File-mounted config mode: edit host <code>config.yaml</code> (mounted as <code>~/.omniagent/config.yaml</code>), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the mounted config file or environment variables.
+            Config file mode: edit your active config file (normally <code>~/.omniagent/config.yaml</code>; Docker Compose mounts <code>./config.yaml</code> there), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the config file or environment variables.
           </div>
           <div class="provider-list" id="providers-list"></div>
+        </div>
+      </details>
+      <details class="form-section" open>
+        <summary>Pricing</summary>
+        <div class="form-body">
+          <div class="provider-note">
+            Manual pricing override for the active <code>provider/model</code>. Values are USD per million tokens. Leave a field blank to omit that rate. Cache creation tokens, if a provider reports them, are estimated at the regular input rate.
+          </div>
+          <div class="pricing-editor">
+            <div class="provider-field">
+              <span class="provider-field-label">Pricing key</span>
+              <span class="provider-field-value" id="cfg-pricing-key">(load config first)</span>
+            </div>
+            <div class="pricing-grid">
+              <div class="pricing-field">
+                <label for="cfg-price-input">Input</label>
+                <input type="number" id="cfg-price-input" min="0" step="any" placeholder="e.g. 5">
+                <small>Uncached input tokens.</small>
+              </div>
+              <div class="pricing-field">
+                <label for="cfg-price-output">Output</label>
+                <input type="number" id="cfg-price-output" min="0" step="any" placeholder="e.g. 30">
+                <small>Generated output tokens.</small>
+              </div>
+              <div class="pricing-field">
+                <label for="cfg-price-cache-read">Cache Read</label>
+                <input type="number" id="cfg-price-cache-read" min="0" step="any" placeholder="e.g. 0.5">
+                <small>Cached input tokens / prompt cache reads.</small>
+              </div>
+            </div>
+          </div>
         </div>
       </details>
     </div>
@@ -947,6 +1085,103 @@ function timeAgo(isoStr) {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return hrs + 'h ago';
   return Math.floor(hrs / 24) + 'd ago';
+}
+
+function formatTokenCount(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return '0';
+  return Math.round(n).toLocaleString();
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined) return '—';
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '—';
+  if (n > 0 && n < 0.1) return '<0.1%';
+  return n.toFixed(1) + '%';
+}
+
+function formatUsd(value) {
+  if (value === null || value === undefined) return '—';
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '—';
+  if (n === 0) return '$0.00';
+  if (Math.abs(n) < 0.0001) return '$' + n.toFixed(8);
+  if (Math.abs(n) < 0.01) return '$' + n.toFixed(6);
+  return '$' + n.toFixed(4);
+}
+
+function usageCacheHitRate(row) {
+  const inputTokens = Number(row?.input_tokens || 0);
+  const cachedTokens = Number(row?.cached_input_tokens ?? row?.cache_read_input_tokens ?? 0);
+  if (!Number.isFinite(inputTokens) || inputTokens <= 0) return null;
+  if (!Number.isFinite(cachedTokens) || cachedTokens <= 0) return 0;
+  return Math.min(100, cachedTokens * 100 / inputTokens);
+}
+
+function formatPricingSource(pricing) {
+  if (!pricing) return 'unpriced';
+  if (pricing.source === 'config') return 'config rule';
+  return pricing.source || 'catalog';
+}
+
+const PRICING_RATE_KEYS = ['input', 'output', 'cache_read'];
+const PRICING_INPUT_IDS = {
+  input: 'cfg-price-input',
+  output: 'cfg-price-output',
+  cache_read: 'cfg-price-cache-read',
+};
+
+function getActivePricingIdentity(config) {
+  const providerName = config?.agent?.model_provider || '';
+  const provider = (config?.providers || {})[providerName] || {};
+  const modelId = provider.model_id || config?.agent?.model_id || '';
+  const usageName = provider.provider_name || providerName;
+  return {
+    providerName,
+    usageName,
+    modelId,
+    pricingKey: usageName && modelId ? `${usageName}/${modelId}` : '',
+  };
+}
+
+function getPricingIdentityFromSettingsForm(config) {
+  const draft = {
+    ...(config || {}),
+    agent: {
+      ...((config && config.agent) || {}),
+      model_provider: document.getElementById('cfg-model-provider')?.value || '',
+      model_id: document.getElementById('cfg-model-id')?.value || '',
+    },
+  };
+  return getActivePricingIdentity(draft);
+}
+
+function copyPricingRule(rule) {
+  const copied = {};
+  if (!rule || typeof rule !== 'object') return copied;
+  for (const key of PRICING_RATE_KEYS) {
+    const value = Number(rule[key]);
+    if (Number.isFinite(value) && value >= 0) copied[key] = value;
+  }
+  return copied;
+}
+
+function setPriceInput(id, value) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.value = value === null || value === undefined ? '' : String(value);
+}
+
+function readOptionalPrice(id, label) {
+  const el = document.getElementById(id);
+  const raw = (el?.value || '').trim();
+  if (!raw) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} price must be a non-negative number`);
+  }
+  return value;
 }
 
 // ── WebSocket ───────────────────────
@@ -1297,6 +1532,7 @@ const panels = {
           const apiUrl = p.api_url || '(default)';
           const modelId = p.model_id || '(not set)';
           const usageName = p.provider_name || name;
+          const pricingKey = p.model_id ? `${usageName}/${p.model_id}` : '(set model_id first)';
           return `
             <div class="provider-card ${isActive ? 'active' : ''}">
               <div class="provider-card-header">
@@ -1306,12 +1542,71 @@ const panels = {
               <div class="provider-field"><span class="provider-field-label">Model ID</span><span class="provider-field-value">${escapeHtml(modelId)}</span></div>
               <div class="provider-field"><span class="provider-field-label">API URL</span><span class="provider-field-value">${escapeHtml(apiUrl)}</span></div>
               <div class="provider-field"><span class="provider-field-label">Usage name</span><span class="provider-field-value">${escapeHtml(usageName)}</span></div>
+              <div class="provider-field"><span class="provider-field-label">Pricing key</span><span class="provider-field-value">${escapeHtml(pricingKey)}</span></div>
               <div class="provider-field"><span class="provider-field-label">API Key</span><span class="provider-field-value secret-mask">${escapeHtml(apiKeyState)}</span></div>
             </div>`;
         }).join('');
       }
+      this.renderPricing(c);
+    },
+    renderPricing(config) {
+      const identity = getActivePricingIdentity(config || {});
+      this.populatePricingFields(config, identity);
+    },
+    renderPricingFromForm() {
+      const current = this._raw || {};
+      const identity = getPricingIdentityFromSettingsForm(current);
+      this.populatePricingFields(current, identity);
+    },
+    populatePricingFields(config, identity) {
+      const pricingKeyEl = document.getElementById('cfg-pricing-key');
+      if (pricingKeyEl) pricingKeyEl.textContent = identity.pricingKey || '(set provider/model first)';
+
+      const overrides = config?.usage?.pricing_overrides || {};
+      const rule = identity.pricingKey ? copyPricingRule(overrides[identity.pricingKey]) : {};
+      for (const key of PRICING_RATE_KEYS) {
+        setPriceInput(PRICING_INPUT_IDS[key], rule[key]);
+      }
+    },
+    buildPricingOverridesForSave() {
+      const current = this._raw || {};
+      const existing = current.usage?.pricing_overrides || {};
+      const overrides = {};
+      for (const [key, rule] of Object.entries(existing)) {
+        const copied = copyPricingRule(rule);
+        if (Object.keys(copied).length) overrides[key] = copied;
+      }
+
+      const identity = getPricingIdentityFromSettingsForm(current);
+      if (!identity.pricingKey) return overrides;
+
+      const edited = {};
+      const labels = {
+        input: 'Input',
+        output: 'Output',
+        cache_read: 'Cache read',
+      };
+      for (const key of PRICING_RATE_KEYS) {
+        const value = readOptionalPrice(PRICING_INPUT_IDS[key], labels[key]);
+        if (value !== undefined) edited[key] = value;
+      }
+
+      if (Object.keys(edited).length) {
+        overrides[identity.pricingKey] = edited;
+      } else {
+        delete overrides[identity.pricingKey];
+      }
+      return overrides;
     },
     async save() {
+      let pricingOverrides;
+      try {
+        pricingOverrides = this.buildPricingOverridesForSave();
+      } catch (error) {
+        showToast(error.message || 'Invalid pricing value', 'error');
+        return;
+      }
+      const usage = { ...((this._raw && this._raw.usage) || {}), pricing_overrides: pricingOverrides };
       const updates = {
         agent: {
           model_provider: document.getElementById('cfg-model-provider').value || undefined,
@@ -1331,6 +1626,7 @@ const panels = {
           port: parseInt(document.getElementById('cfg-port').value) || undefined,
           session_timeout: parseInt(document.getElementById('cfg-session-timeout').value) || undefined,
         },
+        usage,
       };
       // Clean undefined values
       const clean = (obj) => {
@@ -1344,7 +1640,12 @@ const panels = {
       };
       const r = await api.patch('/config', clean(updates));
       if (r.ok) {
-        showToast('Settings saved', 'success');
+        if (r.data?.persisted === false) {
+          showToast(r.data.warning || 'Settings applied for this running process only', 'warning');
+        } else {
+          showToast('Settings saved', 'success');
+        }
+        if (r.data?.config) this._raw = r.data.config;
       } else {
         showToast(r.data.error || 'Save failed', 'error');
       }
@@ -1366,9 +1667,12 @@ const panels = {
     onActivate() { this.load(); this._interval = setInterval(() => this.load(), 10000); },
     onDeactivate() { clearInterval(this._interval); },
     async load() {
-      const r = await api.get('/health');
-      if (!r.ok) return;
-      const h = r.data;
+      const [healthResult, usageResult] = await Promise.all([
+        api.get('/health'),
+        api.get('/usage/summary'),
+      ]);
+      if (!healthResult.ok) return;
+      const h = healthResult.data;
       const cards = document.getElementById('dashboard-cards');
 
       let html = '';
@@ -1406,6 +1710,8 @@ const panels = {
         <div class="stat-row"><span class="stat-label">WebSocket</span><span class="stat-value">${ws && ws.readyState === WebSocket.OPEN ? 'Connected' : 'Disconnected'}</span></div>
       </div>`;
 
+      html += this.renderUsageCard(usageResult);
+
       // Channels card
       if (h.channels && Object.keys(h.channels).length) {
         html += '<div class="card"><h3>Channels</h3><div class="channel-list">';
@@ -1436,6 +1742,58 @@ const panels = {
       }
 
       cards.innerHTML = html;
+    },
+    renderUsageCard(result) {
+      let html = '<div class="card usage-card"><h3>Today\'s Usage by Provider / Model</h3>';
+      if (!result?.ok) {
+        return `${html}<div class="usage-empty">Usage summary is unavailable right now.</div></div>`;
+      }
+
+      const usage = result.data.usage || {};
+      const totals = usage.totals || {};
+      const rows = Array.isArray(usage.by_model) ? usage.by_model : [];
+      const pricedModels = Number(totals.priced_models || 0);
+      const unpricedModels = Number(totals.unpriced_models || 0);
+      const estimatedTotalCost = pricedModels > 0 ? formatUsd(totals.estimated_cost_usd) : '—';
+      const pricingUnit = usage.pricing?.unit || 'USD per million tokens';
+      const cacheHitRate = usageCacheHitRate(totals);
+
+      html += '<div class="usage-summary">';
+      html += `<div class="usage-metric"><div class="usage-metric-label">Total Tokens</div><div class="usage-metric-value">${formatTokenCount(totals.total_tokens)}</div></div>`;
+      html += `<div class="usage-metric"><div class="usage-metric-label">Input Tokens</div><div class="usage-metric-value">${formatTokenCount(totals.input_tokens)}</div></div>`;
+      html += `<div class="usage-metric"><div class="usage-metric-label">Cache Input</div><div class="usage-metric-value">${formatTokenCount(totals.cached_input_tokens)}</div></div>`;
+      html += `<div class="usage-metric"><div class="usage-metric-label">Output Tokens</div><div class="usage-metric-value">${formatTokenCount(totals.output_tokens)}</div></div>`;
+      html += `<div class="usage-metric"><div class="usage-metric-label">Cache Hit Rate</div><div class="usage-metric-value">${formatPercent(cacheHitRate)}</div></div>`;
+      html += `<div class="usage-metric"><div class="usage-metric-label">Estimated Cost</div><div class="usage-metric-value">${estimatedTotalCost}</div></div>`;
+      html += '</div>';
+
+      if (!rows.length) {
+        html += '<div class="usage-empty">No LLM usage has been recorded for today yet.</div>';
+      } else {
+        html += '<div class="usage-table-wrap"><table class="usage-table"><thead><tr>';
+        html += '<th>Provider</th><th>Model</th><th>Total</th><th>Input</th><th>Cache Input</th><th>Output</th><th>Cache Hit</th><th>Cost</th><th>Pricing</th>';
+        html += '</tr></thead><tbody>';
+        for (const row of rows) {
+          const rowCost = row.estimated_cost_usd === null || row.estimated_cost_usd === undefined ? '—' : formatUsd(row.estimated_cost_usd);
+          html += '<tr>';
+          html += `<td>${escapeHtml(row.provider || 'unknown')}</td>`;
+          html += `<td class="model-cell">${escapeHtml(row.model_id || 'unknown')}</td>`;
+          html += `<td class="numeric">${formatTokenCount(row.total_tokens)}</td>`;
+          html += `<td class="numeric">${formatTokenCount(row.input_tokens)}</td>`;
+          html += `<td class="numeric">${formatTokenCount(row.cached_input_tokens)}</td>`;
+          html += `<td class="numeric">${formatTokenCount(row.output_tokens)}</td>`;
+          html += `<td class="numeric">${formatPercent(usageCacheHitRate(row))}</td>`;
+          html += `<td class="numeric">${rowCost}</td>`;
+          html += `<td>${escapeHtml(formatPricingSource(row.pricing))}</td>`;
+          html += '</tr>';
+        }
+        html += '</tbody></table></div>';
+      }
+
+      const costScope = totals.estimated_cost_scope === 'returned_models' ? 'returned provider/model rows' : 'all matched rows';
+      html += `<div class="usage-note">Cost is estimated from manual <code>usage.pricing_overrides</code> provider/model rules first. Supported rates are <code>input</code>, <code>output</code>, and <code>cache_read</code>; otherwise OmniAgent uses the remote models.dev catalog only when provider/model or an unambiguous model_id can be matched. Coverage: ${pricedModels} priced, ${unpricedModels} unpriced. Scope: ${escapeHtml(costScope)}. Unit: ${escapeHtml(pricingUnit)}.</div>`;
+      html += '</div>';
+      return html;
     },
   },
 

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -395,6 +395,79 @@ body {
 }
 .form-row .toggle.active::after { transform: translateX(18px); }
 .form-hint { font-size: 11px; color: var(--text-dim); margin-left: 172px; }
+.provider-note {
+  padding: 10px 12px;
+  background: var(--accent-soft);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+.provider-note code {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.08);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.provider-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.provider-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.provider-card.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
+}
+.provider-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.provider-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.provider-field {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 8px;
+  font-size: 12px;
+}
+.provider-field-label { color: var(--text-dim); }
+.provider-field-value {
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+.provider-empty {
+  grid-column: 1 / -1;
+  padding: 12px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.provider-empty code,
+.provider-note code {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.08);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.secret-mask { color: var(--warning); }
 .form-actions-bar {
   display: flex; gap: 8px; padding: 16px 24px;
   border-top: 1px solid var(--border);
@@ -790,7 +863,12 @@ body {
       </details>
       <details class="form-section">
         <summary>Providers</summary>
-        <div class="form-body" id="providers-list"></div>
+        <div class="form-body">
+          <div class="provider-note">
+            Docker/file-mounted config mode: edit host <code>config.yaml</code> (mounted as <code>~/.omniagent/config.yaml</code>), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the mounted config file or environment variables.
+          </div>
+          <div class="provider-list" id="providers-list"></div>
+        </div>
       </details>
     </div>
     <div class="form-actions-bar">
@@ -1204,17 +1282,33 @@ const panels = {
       // Providers
       const provList = document.getElementById('providers-list');
       const provs = c.providers || {};
-      if (!Object.keys(provs).length) {
-        provList.innerHTML = '<p style="font-size:13px;color:var(--text-dim)">No providers configured</p>';
+      const activeProvider = (c.agent && c.agent.model_provider) || '';
+      const entries = Object.entries(provs);
+      if (!entries.length) {
+        provList.innerHTML = `
+          <div class="provider-empty">
+            No provider presets configured. Edit <code>config.yaml</code> on the VM, add a <code>providers:</code> section, then click <strong>Reload from Disk</strong>.
+          </div>`;
       } else {
-        provList.innerHTML = Object.entries(provs).map(([name, p]) => `
-          <div style="display:flex;flex-direction:column;gap:6px;padding:8px 0;border-bottom:1px solid var(--border)">
-            <div style="font-size:13px;font-weight:600">${escapeHtml(name)}</div>
-            <div class="form-row"><label style="min-width:100px">API Key</label><span style="font-size:12px;color:var(--text-dim)">${escapeHtml(p.api_key || '(not set)')}</span></div>
-            <div class="form-row"><label style="min-width:100px">API URL</label><span style="font-size:12px;color:var(--text-secondary)">${escapeHtml(p.api_url || '(default)')}</span></div>
-            ${p.model ? `<div class="form-row"><label style="min-width:100px">Model</label><span style="font-size:12px;color:var(--text-secondary)">${escapeHtml(p.model)}</span></div>` : ''}
-          </div>
-        `).join('');
+        provList.innerHTML = entries.map(([name, provider]) => {
+          const p = provider || {};
+          const isActive = name === activeProvider;
+          const apiKeyState = p.api_key ? 'configured (masked)' : 'not set';
+          const apiUrl = p.api_url || '(default)';
+          const modelId = p.model_id || '(not set)';
+          const usageName = p.provider_name || name;
+          return `
+            <div class="provider-card ${isActive ? 'active' : ''}">
+              <div class="provider-card-header">
+                <span class="provider-name">${escapeHtml(name)}</span>
+                ${isActive ? '<span class="badge badge-success">ACTIVE</span>' : '<span class="badge badge-muted">preset</span>'}
+              </div>
+              <div class="provider-field"><span class="provider-field-label">Model ID</span><span class="provider-field-value">${escapeHtml(modelId)}</span></div>
+              <div class="provider-field"><span class="provider-field-label">API URL</span><span class="provider-field-value">${escapeHtml(apiUrl)}</span></div>
+              <div class="provider-field"><span class="provider-field-label">Usage name</span><span class="provider-field-value">${escapeHtml(usageName)}</span></div>
+              <div class="provider-field"><span class="provider-field-label">API Key</span><span class="provider-field-value secret-mask">${escapeHtml(apiKeyState)}</span></div>
+            </div>`;
+        }).join('');
       }
     },
     async save() {

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -1135,7 +1135,7 @@ const PRICING_INPUT_IDS = {
 function getActivePricingIdentity(config) {
   const providerName = config?.agent?.model_provider || '';
   const provider = (config?.providers || {})[providerName] || {};
-  const modelId = config?.agent?.model_id || provider.model_id || '';
+  const modelId = config?.agent?.model_id || '';
   return {
     providerName,
     apiType: provider.api_type || providerName,
@@ -1529,7 +1529,7 @@ const panels = {
           const isActive = name === activeProvider;
           const apiKeyState = p.api_key ? 'configured (masked)' : 'not set';
           const apiUrl = p.api_url || '(default)';
-          const activeModelId = c.agent?.model_id || p.model_id || '';
+          const activeModelId = c.agent?.model_id || '';
           const providerModelId = p.model_id || '';
           const modelId = (isActive ? activeModelId : providerModelId) || '(not set)';
           const modelLabel = isActive ? 'Active Model ID' : 'Default Model ID';
@@ -1613,15 +1613,20 @@ const panels = {
         return;
       }
       const usage = { ...((this._raw && this._raw.usage) || {}), pricing_overrides: pricingOverrides };
+      const currentModelId = this._raw?.agent?.model_id || '';
+      const nextModelId = document.getElementById('cfg-model-id').value || '';
+      const agentUpdates = {
+        model_provider: document.getElementById('cfg-model-provider').value || undefined,
+        temperature: parseFloat(document.getElementById('cfg-temperature').value),
+        max_tokens: parseInt(document.getElementById('cfg-max-tokens').value) || undefined,
+        max_iterations: parseInt(document.getElementById('cfg-max-iterations').value) || undefined,
+        reflexion_enabled: document.getElementById('cfg-reflexion').classList.contains('active'),
+      };
+      if (nextModelId !== currentModelId) {
+        agentUpdates.model_id = nextModelId;
+      }
       const updates = {
-        agent: {
-          model_provider: document.getElementById('cfg-model-provider').value || undefined,
-          model_id: document.getElementById('cfg-model-id').value || undefined,
-          temperature: parseFloat(document.getElementById('cfg-temperature').value),
-          max_tokens: parseInt(document.getElementById('cfg-max-tokens').value) || undefined,
-          max_iterations: parseInt(document.getElementById('cfg-max-iterations').value) || undefined,
-          reflexion_enabled: document.getElementById('cfg-reflexion').classList.contains('active'),
-        },
+        agent: agentUpdates,
         tools: { profile: document.getElementById('cfg-tool-profile').value },
         enable_progressive_loading: document.getElementById('cfg-progressive-loading').classList.contains('active'),
         enable_parallel_execution: document.getElementById('cfg-parallel-exec').classList.contains('active'),
@@ -1651,7 +1656,7 @@ const panels = {
         } else {
           showToast('Settings saved', 'success');
         }
-        if (r.data?.config) this._raw = r.data.config;
+        if (r.data?.config) { this._raw = r.data.config; this.loadConfig(); }
       } else {
         showToast(r.data.error || 'Save failed', 'error');
       }

--- a/omniagent/gateway/web_ui.html
+++ b/omniagent/gateway/web_ui.html
@@ -891,8 +891,8 @@ body {
         <summary>Agent</summary>
         <div class="form-body">
           <div class="form-row">
-            <label>Model Provider</label>
-            <input type="text" id="cfg-model-provider" placeholder="e.g. openai, deepseek" oninput="panels.settings.renderPricingFromForm()">
+            <label>Provider Key</label>
+            <input type="text" id="cfg-model-provider" placeholder="e.g. openai, byr" oninput="panels.settings.renderPricingFromForm()">
           </div>
           <div class="form-row">
             <label>Model ID</label>
@@ -972,7 +972,7 @@ body {
         <summary>Providers</summary>
         <div class="form-body">
           <div class="provider-note">
-            Config file mode: edit your active config file (normally <code>~/.omniagent/config.yaml</code>; Docker Compose mounts <code>./config.yaml</code> there), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the config file or environment variables.
+            Config file mode: edit your active config file (normally <code>~/.omniagent/config.yaml</code>, or the path passed with <code>--config</code>), then click <strong>Reload from Disk</strong>. API keys are masked here and should be supplied through the config file or environment variables.
           </div>
           <div class="provider-list" id="providers-list"></div>
         </div>
@@ -1135,13 +1135,12 @@ const PRICING_INPUT_IDS = {
 function getActivePricingIdentity(config) {
   const providerName = config?.agent?.model_provider || '';
   const provider = (config?.providers || {})[providerName] || {};
-  const modelId = provider.model_id || config?.agent?.model_id || '';
-  const usageName = provider.provider_name || providerName;
+  const modelId = config?.agent?.model_id || provider.model_id || '';
   return {
     providerName,
-    usageName,
+    apiType: provider.api_type || providerName,
     modelId,
-    pricingKey: usageName && modelId ? `${usageName}/${modelId}` : '',
+    pricingKey: providerName && modelId ? `${providerName}/${modelId}` : '',
   };
 }
 
@@ -1530,18 +1529,25 @@ const panels = {
           const isActive = name === activeProvider;
           const apiKeyState = p.api_key ? 'configured (masked)' : 'not set';
           const apiUrl = p.api_url || '(default)';
-          const modelId = p.model_id || '(not set)';
-          const usageName = p.provider_name || name;
-          const pricingKey = p.model_id ? `${usageName}/${p.model_id}` : '(set model_id first)';
+          const activeModelId = c.agent?.model_id || p.model_id || '';
+          const providerModelId = p.model_id || '';
+          const modelId = (isActive ? activeModelId : providerModelId) || '(not set)';
+          const modelLabel = isActive ? 'Active Model ID' : 'Default Model ID';
+          const apiType = p.api_type || name;
+          const apiTypeRow = apiType && apiType !== name
+            ? `<div class="provider-field"><span class="provider-field-label">API Type</span><span class="provider-field-value">${escapeHtml(apiType)}</span></div>`
+            : '';
+          const pricingModelId = isActive ? activeModelId : providerModelId;
+          const pricingKey = pricingModelId ? `${name}/${pricingModelId}` : '(set model_id first)';
           return `
             <div class="provider-card ${isActive ? 'active' : ''}">
               <div class="provider-card-header">
                 <span class="provider-name">${escapeHtml(name)}</span>
                 ${isActive ? '<span class="badge badge-success">ACTIVE</span>' : '<span class="badge badge-muted">preset</span>'}
               </div>
-              <div class="provider-field"><span class="provider-field-label">Model ID</span><span class="provider-field-value">${escapeHtml(modelId)}</span></div>
+              <div class="provider-field"><span class="provider-field-label">${modelLabel}</span><span class="provider-field-value">${escapeHtml(modelId)}</span></div>
+              ${apiTypeRow}
               <div class="provider-field"><span class="provider-field-label">API URL</span><span class="provider-field-value">${escapeHtml(apiUrl)}</span></div>
-              <div class="provider-field"><span class="provider-field-label">Usage name</span><span class="provider-field-value">${escapeHtml(usageName)}</span></div>
               <div class="provider-field"><span class="provider-field-label">Pricing key</span><span class="provider-field-value">${escapeHtml(pricingKey)}</span></div>
               <div class="provider-field"><span class="provider-field-label">API Key</span><span class="provider-field-value secret-mask">${escapeHtml(apiKeyState)}</span></div>
             </div>`;

--- a/omniagent/rl/__init__.py
+++ b/omniagent/rl/__init__.py
@@ -5,7 +5,7 @@ RL training pipeline for OmniAgent:
 - Async rollout worker (rollout.py) bridging proxy and SLIME trainer
 - Config adapter (config.py) converting OmniAgent RLConfig to args namespace
 
-**Only activates when model_provider is "vllm" or "sglang".**
+**Only activates when api_type is "vllm" or "sglang".**
 When using remote LLM providers (DeepSeek, OpenAI, etc.), RL is completely
 disabled and zero overhead.
 

--- a/omniagent/rl/api_server.py
+++ b/omniagent/rl/api_server.py
@@ -4,7 +4,7 @@ FastAPI proxy server between external agents and SGLang inference engine.
 Handles logprob collection, PRM scoring, training sample construction,
 and submission to the rollout worker.
 
-Only activates when model_provider is "vllm" or "sglang".
+Only activates when api_type is "vllm" or "sglang".
 
 """
 

--- a/omniagent/rl/rollout.py
+++ b/omniagent/rl/rollout.py
@@ -5,7 +5,7 @@ SLIME training loop. Data production is request-driven: external
 agents send requests through the proxy, which collects training
 samples.
 
-Only activates when model_provider is "vllm" or "sglang".
+Only activates when api_type is "vllm" or "sglang".
 
 """
 


### PR DESCRIPTION
## What & Why

Two related changes in this PR:

1. **Usage Dashboard** — A new background usage ledger that tracks LLM token consumption and estimates cost (via models.dev pricing). Previously there was no way to see how many tokens were being consumed or what it cost.
2. **Provider Config Rework** — Provider entries now have an explicit `api_type` field, decoupling the provider key (used as identity for usage rows, pricing overrides, and model selection) from the API implementation. This fixes confusion when multiple OpenAI-compatible backends share the same key name, and enables custom named providers.

18 files · +2,401 −321

---

## Changes by Area

### 1. New: Usage Ledger (`omniagent/agents/usage.py`)

Entirely self-contained module (669 lines). No new dependencies beyond `sqlite3` (stdlib).

**Architecture:**

```
LLM response → UsageTrackingLLMProvider (proxy, non-blocking)
                 │
                 ▼
           UsageRecorder.record_response()
                 │
                 ▼
           bounded queue (max 10k)
                 │
                 ▼
         background writer thread → SQLite (WAL mode)
```

**Design decisions worth reviewing:**
- Writes are **fire-and-forget**: queue full → drop event and log debug. A stuck DB *never* blocks the LLM response path.
- `UsageTrackingLLMProvider` is a proxy wrapping the real provider; it delegates everything except `chat()` and `chat_stream()`, where it records usage after the response returns.
- Context (session_id, user_id, channel_id) is propagated via `ContextVar` so it works across async boundaries without threading issues.
- Pricing catalog is fetched from `https://models.dev/api.json` with a thread-safe in-memory cache (default TTL: 900s, timeout: 2s). Catalog fetch failure leaves existing cache intact.
- Cost estimation is conservative: if a `model_id` has different prices across multiple providers in the catalog, the bare-model-id fallback is skipped — no guessing.

**Review focus:**
- `normalize_usage()` — handles the inconsistent usage shapes from OpenAI/Anthropic/DeepSeek/etc. Check that `input_tokens_uncached` and `cache_read_input_tokens` are computed correctly for your provider.
- `_writer_loop()` — daemon thread lifecycle. `close()` sends a sentinel `None` and sets a stop event; check shutdown doesn't leave queued events stranded.

### 2. New: Config Template (`config.example.yaml`)

A complete annotated config showing all supported sections: providers, agent, gateway, usage, tools, feature flags. Safe to commit — API keys use `${ENV_VAR:-}` syntax.

Used by CLI onboarding (`omniagent onboard`) as the starting template.

### 3. Provider Config Rework (`omniagent/config/models.py`)

**What changed:**

- `ProviderConfig` gained `api_type: Optional[str]` field. Built-in keys (`deepseek`, `openai`, etc.) auto-infer their `api_type`. Named keys (e.g. `my-backend`) MUST explicitly set `api_type: openai-compatible`.
- `provider_name` (legacy) is stripped from config at validation time and migrated to `api_type` with automatic alias resolution.
- Pricing override keys are automatically migrated when provider keys are renamed.
- `UsageConfig` (`usage.*` section) is new — controls pricing catalog behavior and manual overrides.
- `GatewayConfig` gained `usage_summary_max_days` to cap the summary query window.
- `AgentConfig` gained `model_id` field for the active model override.
- `OmniAgentConfig._normalize_provider_layout()` handles all legacy → new migration in one model validator.

**Review focus:**
- `_normalize_provider_layout()` — the migration logic is the most complex part. Check the rename aliasing (`provider_name` → `api_type`) and pricing key migration for edge cases (duplicate keys, conflicting aliases).
- `_validate_active_provider_key()` — ensures the `agent.model_provider` key exists in `providers` with a valid `api_type`. Should fail fast on misconfiguration.
- `_strip_legacy_provider_name()` — strips `provider_name` from each provider entry so it never reaches downstream code.

### 4. Gateway Integration (`omniagent/gateway/`)

- **`server.py`**: Initializes `UsageRecorder` on startup, passes it through the app state. The DB path defaults to `{work_dir}/.omniagent/usage.db`.
- **`api.py`**: New `GET /api/usage/summary` endpoint with `?days=N&limit=M` query params. Defaults to today's window. Response includes totals, per-model breakdown, cost estimates, queue health metrics.
- **`web_ui.html`**: Usage stats displayed in the web dashboard.

**Review focus:**
- The usage summary endpoint reads directly from SQLite (no queue). This is intentional — summary is a light read on a WAL-mode DB.
- Days param is capped by `GatewayConfig.usage_summary_max_days` (default 365) to prevent full-table scans.

### 5. LLM Agent Integration (`omniagent/agents/llm.py`)

Provider and model metadata (`response.metadata["provider"]`, `response.metadata["model"]`) are now attached to LLM responses so `UsageTrackingLLMProvider` can record them without guessing.

### 6. Agent Loop Changes

- **`reflexion.py`**: Passes usage context (session, user, channel) through the tracking proxy.
- **`skill_evolution.py`**: Same — sets usage context before LLM calls.
- **`cli/chat.py`**: Displays usage summary after chat sessions.
- **`cli/main.py`**: Onboarding flow uses the new `config.example.yaml` template.

### 7. RL Module (`omniagent/rl/`)

Minor wording change: RL activation check now reads `api_type` instead of `model_provider` from the active provider config (`__init__.py`, `api_server.py`, `rollout.py`). No behavioral change — just follows the `ProviderConfig.api_type` addition.

### 8. Docs & UI

- `README.md`, `README_CN.md`: Updated configuration examples to show `api_type` and `usage` sections.
- `index.html`: Landing page reflects new features.
- `.gitignore`: Added `*.db` to exclude the usage SQLite DB.

---

## Migration & Compatibility

| What | Behavior |
|------|----------|
| Existing configs without `api_type` | Auto-inferred from provider key name. No action needed for built-in keys (`deepseek`, `openai`, etc.). |
| Configs using `provider_name` | Automatically stripped and migrated to `api_type`. Pricing override keys follow the rename. |
| Named providers without `api_type` | **Validation error** — must add `api_type`. This is intentional (fail-fast). |
| New `usage.*` config section | Defaults to enabled with models.dev catalog. Opt out with `pricing_catalog_enabled: false`. |
| Usage DB location | `{work_dir}/.omniagent/usage.db`. Created automatically on first gateway startup. |

---

## Things to Check in Review

- [ ] **Pricing correctness**: Spot-check cost estimates for a few known models against published pricing. The `pricing_overrides` test in `config.example.yaml` shows the expected key format.
- [ ] **Provider migration edge cases**: Try configs with `provider_name` set to the same value as another provider key, or with empty `api_type` on a named provider — should fail validation cleanly.
- [ ] **Queue overflow behavior**: If the gateway is under load, the usage queue might fill. Verify dropped events are logged at debug level and don't surface as errors to users.
- [ ] **DB file location**: The DB is created in `work_dir/.omniagent/`. Verify this works in Docker deployments where the work_dir is mounted.
- [ ] **Thread safety**: The catalog cache lock (`_MODELS_DEV_CACHE_LOCK`) and the queue are the only shared state. The SQLite connection is single-threaded (writer loop owns it).
- [ ] **ContextVar propagation**: Usage context must survive across async `await` boundaries in the reflexion loop. Test with `omniagent chat` and verify the web UI shows per-session breakdowns.
