### PR TITLE
bug: llm config setting fix

### DIFF
--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -73,34 +73,7 @@ class ReflexionAgent(Agent):
 
         # Create LLM provider
         if llm_provider is None:
-            # Resolve provider-specific overrides
-            provider_name = config.agent.model_provider
-            provider_cfg = config.providers.get(provider_name) if config.providers else None
-
-            provider_api_url = config.agent.api_url
-            provider_model = config.agent.model_id
-            provider_api_key = ""
-
-            if provider_cfg:
-                if provider_cfg.api_url:
-                    provider_api_url = provider_cfg.api_url
-                if provider_cfg.model_id:
-                    provider_model = provider_cfg.model_id
-                provider_api_key = provider_cfg.api_key or ""
-
-            # Fallback to top-level api_key
-            if not provider_api_key:
-                provider_api_key = config.api_key or config.openai_api_key or ""
-
-            # Sync resolved model back to config so system prompt uses it
-            config.agent.model_id = provider_model
-
-            llm_provider = create_llm_provider(
-                provider=provider_name,
-                api_key=provider_api_key,
-                model=provider_model,
-                api_url=provider_api_url,
-            )
+            llm_provider = self._create_llm_from_config(config)
 
         self.llm = llm_provider
 
@@ -315,6 +288,32 @@ class ReflexionAgent(Agent):
             tools_count=len(self.tools),
             security_enabled=enable_security,
             native_fc=self.llm.supports_native_function_calling,
+        )
+
+    def _create_llm_from_config(self, config: OmniAgentConfig) -> LLMProvider:
+        provider_name = config.agent.model_provider
+        provider_cfg = config.providers.get(provider_name) if config.providers else None
+
+        provider_api_url = config.agent.api_url
+        provider_model = config.agent.model_id
+        provider_api_key = ""
+
+        if provider_cfg:
+            if provider_cfg.api_url:
+                provider_api_url = provider_cfg.api_url
+            if provider_cfg.model_id:
+                provider_model = provider_cfg.model_id
+            provider_api_key = provider_cfg.api_key or ""
+
+        if not provider_api_key:
+            provider_api_key = config.api_key or config.openai_api_key or ""
+
+        config.agent.model_id = provider_model
+        return create_llm_provider(
+            provider=provider_name,
+            api_key=provider_api_key,
+            model=provider_model,
+            api_url=provider_api_url,
         )
 
     def steer(self, message: str) -> None:

--- a/omniagent/agents/reflexion.py
+++ b/omniagent/agents/reflexion.py
@@ -301,14 +301,11 @@ class ReflexionAgent(Agent):
         if provider_cfg:
             if provider_cfg.api_url:
                 provider_api_url = provider_cfg.api_url
-            if provider_cfg.model_id:
-                provider_model = provider_cfg.model_id
             provider_api_key = provider_cfg.api_key or ""
 
         if not provider_api_key:
             provider_api_key = config.api_key or config.openai_api_key or ""
 
-        config.agent.model_id = provider_model
         return create_llm_provider(
             provider=provider_name,
             api_key=provider_api_key,

--- a/omniagent/gateway/api.py
+++ b/omniagent/gateway/api.py
@@ -125,6 +125,7 @@ async def update_config(request: web.Request) -> web.Response:
     ctx.config = new_config
     if ctx.agent is not None:
         ctx.agent.config = new_config
+        ctx.agent.llm = ctx.agent._create_llm_from_config(new_config)
 
     result = new_config.model_dump(mode="json")
     _mask_sensitive_fields(result)
@@ -145,6 +146,7 @@ async def reload_config_handler(request: web.Request) -> web.Response:
     ctx.config = reloaded
     if ctx.agent is not None:
         ctx.agent.config = reloaded
+        ctx.agent.llm = ctx.agent._create_llm_from_config(reloaded)
 
     return web.json_response({"status": "reloaded"})
 


### PR DESCRIPTION
## What this fixes

Two bugs in config update/reload:

1. **Model not applied at runtime.** `PATCH /api/config` and `POST /api/config/reload` update the config object but never rebuild the live LLM provider — the old model stays in effect until container restart.

2. **Provider default overrides user's model.** `providers.X.model_id` unconditionally overwrites `agent.model_id`, so even when the PATCH succeeds, the resolved model is the provider default rather than what the user explicitly set.

## Changes

**`omniagent/agents/reflexion.py`** (extract helper + remove override)

- Extracted the provider-resolution block from `__init__` into `_create_llm_from_config()`. Startup behavior unchanged.
- Removed the two lines that let `providers.X.model_id` override `agent.model_id`. The provider's `model_id` is now treated as a default for onboarding, not a runtime override.
- Removed the now-redundant `config.agent.model_id = provider_model` sync.

**`omniagent/gateway/api.py`** (+2 lines)

Both `update_config` and `reload_config_handler` now call `_create_llm_from_config` on the new config, rebuilding the live LLM provider immediately:

```
ctx.agent.llm = ctx.agent._create_llm_from_config(new_config)
```

## Design note

A full agent rebuild was rejected — the router in `cli/main.py` closes over the original agent instance, so swapping `ctx.agent` would create a split-brain between API and message routing. This fix keeps the same agent object and only swaps the cached LLM provider.

## Before / after

| Action | Before | After |
|--------|--------|-------|
| PATCH `{"agent":{"model_id":"kimi-2.6"}}` | Config saved, but LLM still uses old model | Config saved, LLM immediately uses `kimi-2.6` |
| Change `agent.model_id` in config.yaml + reload | Config loaded, LLM unchanged | Config loaded, LLM picks up new model |
| Set `agent.model_id` different from `providers.custom.model_id` | Provider default wins | User's `agent.model_id` wins |

## How to verify

1. Start with `model_id: gpt-5.4`
2. PATCH to `model_id: kimi-2.6` or change config.yaml and reload
3. Next LLM call uses `kimi-2.6` — no container restart needed

## Scope

Only LLM provider/model/api fields are hot-reloaded. Host/port, feature flags, and tool profiles are not in scope for this PR.
